### PR TITLE
1, 2주차 필요한 Domain 설계 및 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Created by https://www.toptal.com/developers/gitignore/api/intellij+all,java,gradle,macos,windows
 # Edit at https://www.toptal.com/developers/gitignore?templates=intellij+all,java,gradle,macos,windows
 
+### Custom - Team WithMe ###
+/src/main/resources/data.sql
+
 ### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/src/main/java/com/umc/withme/WithMeApplication.java
+++ b/src/main/java/com/umc/withme/WithMeApplication.java
@@ -2,7 +2,9 @@ package com.umc.withme;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class WithMeApplication {
 

--- a/src/main/java/com/umc/withme/domain/Address.java
+++ b/src/main/java/com/umc/withme/domain/Address.java
@@ -31,7 +31,6 @@ public class Address {
     // 코드 추가는 여기에
 
     // Equals and HashCode
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/umc/withme/domain/Address.java
+++ b/src/main/java/com/umc/withme/domain/Address.java
@@ -1,0 +1,47 @@
+package com.umc.withme.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Address {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String sido;
+
+    @Column(nullable = false, length = 10)
+    private String sgg;
+
+    // Constructor
+    public Address(String sido, String sgg) {
+        this.sido = sido;
+        this.sgg = sgg;
+    }
+
+    // 코드 추가는 여기에
+
+    // Equals and HashCode
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Address)) return false;
+        Address that = (Address) o;
+        return this.getId() != null && this.getId().equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getId());
+    }
+}

--- a/src/main/java/com/umc/withme/domain/Meet.java
+++ b/src/main/java/com/umc/withme/domain/Meet.java
@@ -1,0 +1,87 @@
+package com.umc.withme.domain;
+
+import com.umc.withme.domain.common.BaseEntity;
+import com.umc.withme.domain.constant.MeetCategory;
+import com.umc.withme.domain.constant.MeetStatus;
+import com.umc.withme.domain.constant.RecruitStatus;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Meet extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meet_id")
+    private Long id;
+
+    @JoinColumn(name = "leader_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member leader;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MeetCategory category;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private RecruitStatus recruitStatus;
+
+    @Enumerated(EnumType.STRING)
+    private MeetStatus meetStatus;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private Integer minPeople;
+
+    @Column(nullable = false)
+    private Integer maxPeople;
+
+    private String link;
+
+    @Column(length = 2000, nullable = false)
+    private String content;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    // Builder & Constructor
+    @Builder
+    private Meet(Member leader, MeetCategory category, RecruitStatus recruitStatus, String title, Integer minPeople, Integer maxPeople, String link, String content) {
+        this.leader = leader;
+        this.category = category;
+        this.recruitStatus = recruitStatus;
+        this.title = title;
+        this.minPeople = minPeople;
+        this.maxPeople = maxPeople;
+        this.link = link;
+        this.content = content;
+    }
+
+    // 코드 추가는 여기에
+
+    // Equals and HashCode
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Meet)) return false;
+        Meet that = (Meet) o;
+        return this.getId() != null && this.getId().equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getId());
+    }
+}

--- a/src/main/java/com/umc/withme/domain/Meet.java
+++ b/src/main/java/com/umc/withme/domain/Meet.java
@@ -58,10 +58,10 @@ public class Meet extends BaseEntity {
 
     // Builder & Constructor
     @Builder
-    private Meet(Member leader, MeetCategory category, RecruitStatus recruitStatus, String title, Integer minPeople, Integer maxPeople, String link, String content) {
+    private Meet(Member leader, MeetCategory category, String title, Integer minPeople, Integer maxPeople, String link, String content) {
         this.leader = leader;
         this.category = category;
-        this.recruitStatus = recruitStatus;
+        this.recruitStatus = RecruitStatus.PROGRESS;
         this.title = title;
         this.minPeople = minPeople;
         this.maxPeople = maxPeople;

--- a/src/main/java/com/umc/withme/domain/MeetMember.java
+++ b/src/main/java/com/umc/withme/domain/MeetMember.java
@@ -1,0 +1,51 @@
+package com.umc.withme.domain;
+
+import com.umc.withme.domain.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class MeetMember extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meet_member_id")
+    private Long id;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "meet_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Meet meet;
+
+    // Builder & Constructor
+    public MeetMember(Member member, Meet meet) {
+        this.member = member;
+        this.meet = meet;
+    }
+
+    // 코드 추가는 여기에
+
+    // Equals and HashCode
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MeetMember)) return false;
+        MeetMember that = (MeetMember) o;
+        return this.getId() != null && this.getId().equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getId());
+    }
+}

--- a/src/main/java/com/umc/withme/domain/Member.java
+++ b/src/main/java/com/umc/withme/domain/Member.java
@@ -25,13 +25,13 @@ public class Member extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Address address;
 
-    @Column(nullable = false)
+    @Column(unique = true, nullable = false)
     private String email;
 
-    @Column(nullable = false)
+    @Column(unique = true, nullable = false)
     private String phoneNumber;
 
-    @Column(nullable = false)
+    @Column(unique = true, nullable = false)
     private String nickname;
 
     @Column(nullable = false)
@@ -46,11 +46,11 @@ public class Member extends BaseTimeEntity {
 
     // Builder & Constructor
     @Builder
-    private Member(Address address, String email, String phoneNumber, String nickname, LocalDate birth, Gender gender) {
+    private Member(Address address, String email, String phoneNumber, LocalDate birth, Gender gender) {
         this.address = address;
         this.email = email;
         this.phoneNumber = phoneNumber;
-        this.nickname = nickname;
+        this.nickname = email;
         this.birth = birth;
         this.gender = gender;
         this.totalPoint = new TotalPoint();

--- a/src/main/java/com/umc/withme/domain/Member.java
+++ b/src/main/java/com/umc/withme/domain/Member.java
@@ -1,0 +1,74 @@
+package com.umc.withme.domain;
+
+import com.umc.withme.domain.common.BaseTimeEntity;
+import com.umc.withme.domain.constant.Gender;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @JoinColumn(name = "address_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Address address;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private LocalDate birth;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Embedded
+    private TotalPoint totalPoint;
+
+    // Builder & Constructor
+    @Builder
+    private Member(Address address, String email, String phoneNumber, String nickname, LocalDate birth, Gender gender) {
+        this.address = address;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.nickname = nickname;
+        this.birth = birth;
+        this.gender = gender;
+        this.totalPoint = new TotalPoint();
+    }
+
+    // 코드 추가는 여기에
+
+    // Equals and HashCode
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Member)) return false;
+        Member that = (Member) o;
+        return this.getId() != null && this.getId().equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getId());
+    }
+}

--- a/src/main/java/com/umc/withme/domain/TotalPoint.java
+++ b/src/main/java/com/umc/withme/domain/TotalPoint.java
@@ -1,5 +1,6 @@
 package com.umc.withme.domain;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,15 +11,15 @@ import javax.persistence.Embeddable;
 @Embeddable
 public class TotalPoint {
 
-    @Setter
+    @Setter(AccessLevel.PRIVATE)
     @Column(nullable = false)
     private Integer attendanceTotalPoint;
 
-    @Setter
+    @Setter(AccessLevel.PRIVATE)
     @Column(nullable = false)
     private Integer passionTotalPoint;
 
-    @Setter
+    @Setter(AccessLevel.PRIVATE)
     @Column(nullable = false)
     private Integer contactTotalPoint;
 

--- a/src/main/java/com/umc/withme/domain/TotalPoint.java
+++ b/src/main/java/com/umc/withme/domain/TotalPoint.java
@@ -1,0 +1,30 @@
+package com.umc.withme.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Getter
+@Embeddable
+public class TotalPoint {
+
+    @Setter
+    @Column(nullable = false)
+    private Integer attendanceTotalPoint;
+
+    @Setter
+    @Column(nullable = false)
+    private Integer passionTotalPoint;
+
+    @Setter
+    @Column(nullable = false)
+    private Integer contactTotalPoint;
+
+    protected TotalPoint() {
+        this.attendanceTotalPoint = 0;
+        this.passionTotalPoint = 0;
+        this.contactTotalPoint = 0;
+    }
+}

--- a/src/main/java/com/umc/withme/domain/common/BaseEntity.java
+++ b/src/main/java/com/umc/withme/domain/common/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.umc.withme.domain.common;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+
+import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity extends BaseTimeEntity {
+
+//    TODO: 인증 기능 구현하며 어떤 값을 넣을지 고민 필요
+//    @CreatedBy
+//    @Column(nullable = false, updatable = false)
+//    protected String createdBy;
+
+//    @LastModifiedBy
+//    @Column(nullable = false,)
+//    protected String modifiedBy;
+}
+

--- a/src/main/java/com/umc/withme/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/umc/withme/domain/common/BaseTimeEntity.java
@@ -1,0 +1,30 @@
+package com.umc.withme.domain.common;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseTimeEntity {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected LocalDateTime modifiedAt;
+}
+

--- a/src/main/java/com/umc/withme/domain/constant/Gender.java
+++ b/src/main/java/com/umc/withme/domain/constant/Gender.java
@@ -1,0 +1,6 @@
+package com.umc.withme.domain.constant;
+
+public enum Gender {
+
+    MALE, FEMALE
+}

--- a/src/main/java/com/umc/withme/domain/constant/MeetCategory.java
+++ b/src/main/java/com/umc/withme/domain/constant/MeetCategory.java
@@ -1,0 +1,6 @@
+package com.umc.withme.domain.constant;
+
+public enum MeetCategory {
+
+    STUDY, HOBBY, EXERCISE, ETC
+}

--- a/src/main/java/com/umc/withme/domain/constant/MeetStatus.java
+++ b/src/main/java/com/umc/withme/domain/constant/MeetStatus.java
@@ -1,0 +1,6 @@
+package com.umc.withme.domain.constant;
+
+public enum MeetStatus {
+
+    PROGRESS, COMPLETE
+}

--- a/src/main/java/com/umc/withme/domain/constant/RecruitStatus.java
+++ b/src/main/java/com/umc/withme/domain/constant/RecruitStatus.java
@@ -1,0 +1,6 @@
+package com.umc.withme.domain.constant;
+
+public enum RecruitStatus {
+
+    PROGRESS, COMPLETE
+}

--- a/src/main/java/com/umc/withme/repository/AddressRepository.java
+++ b/src/main/java/com/umc/withme/repository/AddressRepository.java
@@ -1,0 +1,19 @@
+package com.umc.withme.repository;
+
+import com.umc.withme.domain.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+
+    /**
+     * <p>
+     * 시/도, 시/군/구 정보를 전달받아 일치하는 Address entity를 조회한다.
+     *
+     * @param sido  시/도
+     * @param sgg   시/군/구
+     * @return {@link Address}  조회한 address entity
+     */
+    Optional<Address> findBySidoAndSgg(String sido, String sgg);
+}

--- a/src/main/resources/junit-platform.properties
+++ b/src/main/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.displayname.generator.default=org.junit.jupiter.api.DisplayNameGenerator$ReplaceUnderscores

--- a/src/test/java/com/umc/withme/repository/AddressRepositoryTest.java
+++ b/src/test/java/com/umc/withme/repository/AddressRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.umc.withme.repository;
+
+import com.umc.withme.domain.Address;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayName("Address - Repository Layer Test")
+@DataJpaTest
+class AddressRepositoryTest {
+
+    private AddressRepository addressRepository;
+
+    public AddressRepositoryTest(@Autowired AddressRepository addressRepository) {
+        this.addressRepository = addressRepository;
+    }
+
+    @MethodSource(value = "sggTestData")
+    @ParameterizedTest(name = "[{index}] {0} {1} => PK: {2}")
+    void 시도_시군구_정보가_주어지면_주소를_조회한다(String sido, String sgg, Long addressId) {
+        // given
+
+        // when
+        Address actual = addressRepository.findBySidoAndSgg(sido, sgg)
+                .orElseThrow(EntityNotFoundException::new); // TODO: 추후 Address와 관련된 custom exception으로 변경 고려
+
+        // then
+        assertThat(actual.getId()).isEqualTo(addressId);
+    }
+
+    static Stream<Arguments> sggTestData() {
+        return Stream.of(
+                arguments("서울특별시", "종로구", 1L),
+                arguments("서울특별시", "강남구", 23L),
+                arguments("부산광역시", "해운대구", 34L),
+                arguments("인천광역시", "중구", 50L),
+                arguments("대전광역시", "서구", 67L),
+                arguments("경기도", "수원시 팔달구", 79L),
+                arguments("경기도", "수원시 영통구", 80L),
+                arguments("충청북도", "옥천군", 143L),
+                arguments("전라남도", "보성군", 190L),
+                arguments("경상남도", "창원시 의창구", 234L)
+        );
+    }
+}


### PR DESCRIPTION
This closes #11  

## 작업 사항
### Base Entity 구현
- 생성일과 수정일만 필요한 entity는 `BaseTimeEntity`를, 생성자와 수정자도 필요한 entity는 `BaseEntity`를 상속받아 구현하면 된다. 다만, 현재 생성자와 수정자 정보로 무엇을 넣을지는 아직 결정되지 않았다. 추후 인증 기능을 구현하며 고민해볼 내용이므로 일단은 주석처리하고 추후 변경할 예정.
### 이번 주 작업에 필요한 entity 구현
- `Member`, `Meet`, `MeetMember`, `Address` 네 개의 entity를 ERD 내용을 바탕으로 구현하였다.
- Entity의 필드가 3개 이상인 경우 constructor를 `private`으로 제한하고 builder를 사용하도록 했다. 이렇게 함으로써 팀 내 entity 생성 방식을 통일하고 entity를 생성하는 코드만 보고도 어떤 entity가 생성되는지 쉽게 알 수 있도록 한다. Factory method를 고려해 볼 수도 있겠지만, 혼란스러울 수 있으니 entity 생성 방식을 통일하기로 한다.
- Setter는 class level에 선언하지 않는다. 무분별한 setter 생성은 추후 버그 발생의 원인이 될 수 있으므로 최대한 생성하지 않는다. 필요하다면 필드에 `@Setter` annotation을 사용하여 생성한다. 물론 이때도 범위를 가능하면 사용하는 범위로만 제한하는 것이 좋다.
- 모든 entity는 equals and hashCode 메서드를 구현한다. 이렇게 함으로써 모든 상황에서 더 정확한 동등성 비교가 가능해진다. 현재 기획상 두 entity가 같은 entity인지는 id만 비교하면 될 것이다.
### `Address` 데이터 추가에 따른 Repository layer 구현 및 테스트 작성
- 팀 내 노션 문서에 있는 `data.sql` 파일을 활용하여 `Address` table에 전국 250개의 시/군/구 경계 데이터를 담을 수 있게 되었다.
- 해당 문서는 배포 시 사용하지 않을 것이므로 `.gitignore`에 추가하여 동작하지 않게 한다.
- 실제로 값이 잘 들어가고 잘 조회되는지 테스트해보기 위해 repository layer를 작성하고 그에 대한 테스트 코드를 간단히 작성해보았다.
- 원래 repository layer 구현 및 테스트 작성은 별도의 issue로 분리하여 작업해야 하는게 이상적이지만, 주소 데이터 추가와 연관이 있기도 하고 추후에 수정사항도 적어 한 번 구현해 놓으면 계속 사용할 수 있을 것 같았다. (사실 이슈 만들기 조금 귀찮은 것도 있었습니다 😅)


## 참고 자료
- `data.sql` 행정구역 경계 데이터: [With-Me Notion](https://makeus-challenge.notion.site/7d76674171aa489dbde49431ba1147e1)

## 체크리스트
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?