### PR TITLE
Exception handler에서 Validation 관련 exception인 `ConstraintViolationException`을 처리하지 못하는 문제 해결

### DIFF
--- a/src/main/java/com/umc/withme/exception/ExceptionType.java
+++ b/src/main/java/com/umc/withme/exception/ExceptionType.java
@@ -1,5 +1,6 @@
 package com.umc.withme.exception;
 
+import com.umc.withme.exception.address.AddressNotFoundException;
 import com.umc.withme.exception.common.CustomException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,21 +13,16 @@ import java.util.Objects;
 public enum ExceptionType {
 
     // Common
-    UNHANDLED_EXCEPTION(0, "알 수 없는 서버 에러가 발생했습니다."),
-    METHOD_ARGUMENT_NOT_VALID_EXCEPTION(1, "요청 데이터가 잘못되었습니다."),
+    UNHANDLED_EXCEPTION(0, "알 수 없는 서버 에러가 발생했습니다.", null),
+    BAD_REQUEST_EXCEPTION(1, "요청 데이터가 잘못되었습니다.", null),
 
     // Address
-    ADDRESS_NOT_FOUND_EXCEPTION(3400, "일치하는 주소를 찾을 수 없습니다.")
+    ADDRESS_NOT_FOUND_EXCEPTION(3400, "일치하는 주소를 찾을 수 없습니다.", AddressNotFoundException.class),
     ;
 
     private final int errorCode;
     private final String errorMessage;
     private Class<? extends CustomException> type;
-
-    ExceptionType(int errorCode, String errorMessage) {
-        this.errorCode = errorCode;
-        this.errorMessage = errorMessage;
-    }
 
     public static ExceptionType from(Class<?> classType) {
         return Arrays.stream(values())

--- a/src/main/java/com/umc/withme/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/withme/exception/GlobalExceptionHandler.java
@@ -15,23 +15,32 @@ import javax.validation.ConstraintViolationException;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ErrorResponse> applicationExceptionHandle(CustomException e) {
-        log.error("Application Custom Exception: {}", String.valueOf(e));
+    public ResponseEntity<ErrorResponse> customExceptionHandle(CustomException e) {
+        log.error("CustomException: {}", String.valueOf(e));
 
         return ResponseEntity
                 .status(e.getHttpStatus())
                 .body(new ErrorResponse(e.getErrorCode(), e.getErrorMessage()));
     }
 
-    @ExceptionHandler({
-            ConstraintViolationException.class,
-            MethodArgumentNotValidException.class
-    })
+    @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> methodArgumentNotValidExceptionHandle(MethodArgumentNotValidException e) {
         log.error("MethodArgumentNotValidException: {}", String.valueOf(e));
 
-        int errorCode = ExceptionType.METHOD_ARGUMENT_NOT_VALID_EXCEPTION.getErrorCode();
-        String errorMessage = e.getAllErrors().get(0).getDefaultMessage();
+        int errorCode = ExceptionType.BAD_REQUEST_EXCEPTION.getErrorCode();
+        String errorMessage = ExceptionType.BAD_REQUEST_EXCEPTION.getErrorMessage() + " " + e.getAllErrors().get(0).getDefaultMessage();
+
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse(errorCode, errorMessage));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> constraintViolationExceptionHandle(ConstraintViolationException e) {
+        log.error("ConstraintViolationException: {}", String.valueOf(e));
+
+        int errorCode = ExceptionType.BAD_REQUEST_EXCEPTION.getErrorCode();
+        String errorMessage = ExceptionType.BAD_REQUEST_EXCEPTION.getErrorMessage() + " " + e.getLocalizedMessage();
 
         return ResponseEntity
                 .badRequest()
@@ -39,7 +48,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> runtimeExceptionHandle(Exception e) {
+    public ResponseEntity<ErrorResponse> exceptionHandle(Exception e) {
         StackTraceElement[] stackTrace = e.getStackTrace();
         log.error("UnHandled Exception: {}\n" + "{}:{}:{}", e,
                 stackTrace[0].getClassName(), stackTrace[0].getMethodName(), stackTrace[0].getLineNumber());

--- a/src/main/java/com/umc/withme/exception/common/CustomException.java
+++ b/src/main/java/com/umc/withme/exception/common/CustomException.java
@@ -22,6 +22,6 @@ public class CustomException extends RuntimeException {
         ExceptionType exceptionType = ExceptionType.from(this.getClass());
         this.httpStatus = httpStatus;
         this.errorCode = exceptionType.getErrorCode();
-        this.errorMessage = exceptionType.getErrorMessage() + ", " + optionalMessage;
+        this.errorMessage = exceptionType.getErrorMessage() + " " + optionalMessage;
     }
 }


### PR DESCRIPTION
This closes #31 

## 작업 사항
- 지금까지 `GlobalExceptionHandler`의 `ConstraintViolationException` 처리에 대한 로직이 부실해서 exception handling이 되지 않고 있었다. 그 때문에 이 PR을 통해 controller advice인 `GlobalExceptionHandler`에서 `ConstraintVaiolationException`에 대해서도 적절히 exception handling을 하도록 수정하였음.
- 또한 `ExceptionType`에 선언했던 `AddressNotFoundException`의 누락된 정보를 추가하였다. 추후에도 이런 식으로 누락되지 않도록 `@AllArgsConstructor`를 제외한 모든 constructor를 제거하였음.

## 참고 자료
- None

## 체크리스트
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?