### PR TITLE
특정 닉네임을 가지는 사용자 프로필 조회

### DIFF
--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.umc.withme.controller;
 
 import com.umc.withme.dto.common.DataResponse;
+import com.umc.withme.dto.member.MemberInfoGetResponse;
 import com.umc.withme.dto.member.NicknameDuplicationCheckResponse;
 import com.umc.withme.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,21 @@ public class MemberController {
     @GetMapping("/check/duplicate")
     public ResponseEntity<DataResponse> checkNicknameDuplicate(@RequestParam @NotBlank String nickname) {
         NicknameDuplicationCheckResponse response = NicknameDuplicationCheckResponse.of(memberService.checkNicknameDuplication(nickname));
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new DataResponse(response));
+    }
+
+    /**
+     * 특정 닉네임을 가지는 회원 정보를 조회하는 API
+     *
+     * @param nickname
+     * @return 회원 정보를 DataResponse에 담아 반환
+     */
+    @GetMapping("/users")
+    public ResponseEntity<DataResponse> getMemberInfo(@RequestParam @NotBlank String nickname) {
+        MemberInfoGetResponse response = memberService.getMemberInfo(nickname);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.umc.withme.controller;
 
 import com.umc.withme.dto.common.DataResponse;
+import com.umc.withme.dto.member.MemberDto;
 import com.umc.withme.dto.member.MemberInfoGetResponse;
 import com.umc.withme.dto.member.NicknameDuplicationCheckResponse;
 import com.umc.withme.service.MemberService;
@@ -41,11 +42,12 @@ public class MemberController {
      * 특정 닉네임을 가지는 회원 정보를 조회하는 API
      *
      * @param nickname
-     * @return 회원 정보를 DataResponse에 담아 반환
+     * @return MemberInfoGetResponse에 회원 정보를 담아 DataResponse로 반환
      */
     @GetMapping("/users")
     public ResponseEntity<DataResponse> getMemberInfo(@RequestParam @NotBlank String nickname) {
-        MemberInfoGetResponse response = memberService.getMemberInfo(nickname);
+        MemberDto memberDto = memberService.getMemberInfo(nickname);
+        MemberInfoGetResponse response = MemberInfoGetResponse.from(memberDto);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/umc/withme/dto/member/MemberDto.java
+++ b/src/main/java/com/umc/withme/dto/member/MemberDto.java
@@ -1,0 +1,52 @@
+package com.umc.withme.dto.member;
+
+import com.umc.withme.domain.Address;
+import com.umc.withme.domain.Member;
+import com.umc.withme.domain.TotalPoint;
+import com.umc.withme.domain.constant.Gender;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class MemberDto {
+
+    private Long id;
+    private Address address;
+    private String email;
+    private String phoneNumber;
+    private String nickname;
+    private LocalDate birth;
+    private Gender gender;
+    private TotalPoint totalPoint;
+
+    public static MemberDto of(Long id, Address address, String email, String phoneNumber, String nickname, LocalDate birth, Gender gender, TotalPoint totalPoint) {
+        return new MemberDto(id, address, email, phoneNumber, nickname, birth, gender, totalPoint);
+    }
+
+    public static MemberDto from(Member member) {
+        return MemberDto.of(
+                member.getId(),
+                member.getAddress(),
+                member.getEmail(),
+                member.getPhoneNumber(),
+                member.getNickname(),
+                member.getBirth(),
+                member.getGender(),
+                member.getTotalPoint()
+        );
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .address(address)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .birth(birth)
+                .gender(gender)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/withme/dto/member/MemberInfoGetResponse.java
+++ b/src/main/java/com/umc/withme/dto/member/MemberInfoGetResponse.java
@@ -1,0 +1,25 @@
+package com.umc.withme.dto.member;
+
+import com.umc.withme.domain.Address;
+import com.umc.withme.domain.Member;
+import com.umc.withme.domain.constant.Gender;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class MemberInfoGetResponse {
+
+    private String nickname;
+    private String phoneNumber;
+    private LocalDate birth;
+    private Gender gender;
+    private Address address;
+
+    public static MemberInfoGetResponse from(Member member) {
+        return new MemberInfoGetResponse(member.getNickname(), member.getPhoneNumber(), member.getBirth(), member.getGender(), member.getAddress());
+    }
+}

--- a/src/main/java/com/umc/withme/dto/member/MemberInfoGetResponse.java
+++ b/src/main/java/com/umc/withme/dto/member/MemberInfoGetResponse.java
@@ -1,7 +1,6 @@
 package com.umc.withme.dto.member;
 
 import com.umc.withme.domain.Address;
-import com.umc.withme.domain.Member;
 import com.umc.withme.domain.constant.Gender;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,7 +18,13 @@ public class MemberInfoGetResponse {
     private Gender gender;
     private Address address;
 
-    public static MemberInfoGetResponse from(Member member) {
-        return new MemberInfoGetResponse(member.getNickname(), member.getPhoneNumber(), member.getBirth(), member.getGender(), member.getAddress());
+    public static MemberInfoGetResponse from(MemberDto dto) {
+        return new MemberInfoGetResponse(
+                dto.getNickname(),
+                dto.getPhoneNumber(),
+                dto.getBirth(),
+                dto.getGender(),
+                dto.getAddress()
+        );
     }
 }

--- a/src/main/java/com/umc/withme/exception/ExceptionType.java
+++ b/src/main/java/com/umc/withme/exception/ExceptionType.java
@@ -2,6 +2,7 @@ package com.umc.withme.exception;
 
 import com.umc.withme.exception.address.AddressNotFoundException;
 import com.umc.withme.exception.common.CustomException;
+import com.umc.withme.exception.member.NicknameNotFoundException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -16,9 +17,11 @@ public enum ExceptionType {
     UNHANDLED_EXCEPTION(0, "알 수 없는 서버 에러가 발생했습니다.", null),
     BAD_REQUEST_EXCEPTION(1, "요청 데이터가 잘못되었습니다.", null),
 
+    // Member
+    NICKNAME_NOT_FOUND_EXCEPTION(1400, "해당 닉네임을 가지는 회원이 없습니다.", NicknameNotFoundException.class),
+
     // Address
-    ADDRESS_NOT_FOUND_EXCEPTION(3400, "일치하는 주소를 찾을 수 없습니다.", AddressNotFoundException.class),
-    ;
+    ADDRESS_NOT_FOUND_EXCEPTION(3400, "일치하는 주소를 찾을 수 없습니다.", AddressNotFoundException.class);
 
     private final int errorCode;
     private final String errorMessage;

--- a/src/main/java/com/umc/withme/exception/member/NicknameNotFoundException.java
+++ b/src/main/java/com/umc/withme/exception/member/NicknameNotFoundException.java
@@ -1,0 +1,7 @@
+package com.umc.withme.exception.member;
+
+import com.umc.withme.exception.common.NotFoundException;
+
+public class NicknameNotFoundException extends NotFoundException {
+
+}

--- a/src/main/java/com/umc/withme/repository/MemberRepository.java
+++ b/src/main/java/com/umc/withme/repository/MemberRepository.java
@@ -4,10 +4,9 @@ import com.umc.withme.domain.Member;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
-public interface MemeberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long> {
 
     /**
      * 닉네임을 전달받아 DB에 존재하는지 확인한다.

--- a/src/main/java/com/umc/withme/repository/MemeberRepository.java
+++ b/src/main/java/com/umc/withme/repository/MemeberRepository.java
@@ -1,7 +1,11 @@
 package com.umc.withme.repository;
 
 import com.umc.withme.domain.Member;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface MemeberRepository extends JpaRepository<Member, Long> {
 
@@ -12,4 +16,13 @@ public interface MemeberRepository extends JpaRepository<Member, Long> {
      * @return 존재하는 경우 - true, 존재하지 않는 경우 - false
      */
     boolean existsByNickname(String nickname);
+
+    /**
+     * 해당 닉네임을 가진 Member 객체를 조회한다.
+     *
+     * @param nickname
+     * @return Member 객체
+     */
+    @EntityGraph(attributePaths = {"address"})
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/umc/withme/service/MemberService.java
+++ b/src/main/java/com/umc/withme/service/MemberService.java
@@ -33,8 +33,8 @@ public class MemberService {
      * @throws NicknameNotFoundException 닉네임이 존재하지 않을 경우
      */
     public MemberDto getMemberInfo(String nickname) {
-        Member findMember = memberRepository.findByNickname(nickname)
-                                    .orElseThrow(() -> new NicknameNotFoundException());
-        return MemberDto.from(findMember);
+        return memberRepository.findByNickname(nickname)
+                .map(MemberDto::from)
+                .orElseThrow(NicknameNotFoundException::new);
     }
 }

--- a/src/main/java/com/umc/withme/service/MemberService.java
+++ b/src/main/java/com/umc/withme/service/MemberService.java
@@ -1,5 +1,8 @@
 package com.umc.withme.service;
 
+import com.umc.withme.domain.Member;
+import com.umc.withme.dto.member.MemberInfoGetResponse;
+import com.umc.withme.exception.member.NicknameNotFoundException;
 import com.umc.withme.repository.MemeberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,5 +23,18 @@ public class MemberService {
      */
     public boolean checkNicknameDuplication(String nickname) {
         return memeberRepository.existsByNickname(nickname);
+    }
+
+    /**
+     * 특정 닉네임을 가진 회원 정보를 컨트롤러에게 반환한다.
+     *
+     * @param nickname
+     * @return 회원 정보를 MemberInfoGetResponse 객체로 바꾸어 반환
+     * @throws NicknameNotFoundException 닉네임이 존재하지 않을 경우
+     */
+    public MemberInfoGetResponse getMemberInfo(String nickname) {
+        Member findMember = memeberRepository.findByNickname(nickname)
+                .orElseThrow(() -> new NicknameNotFoundException());
+        return MemberInfoGetResponse.from(findMember);
     }
 }

--- a/src/main/java/com/umc/withme/service/MemberService.java
+++ b/src/main/java/com/umc/withme/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.umc.withme.service;
 
 import com.umc.withme.domain.Member;
+import com.umc.withme.dto.member.MemberDto;
 import com.umc.withme.dto.member.MemberInfoGetResponse;
 import com.umc.withme.exception.member.NicknameNotFoundException;
 import com.umc.withme.repository.MemeberRepository;
@@ -29,12 +30,12 @@ public class MemberService {
      * 특정 닉네임을 가진 회원 정보를 컨트롤러에게 반환한다.
      *
      * @param nickname
-     * @return 회원 정보를 MemberInfoGetResponse 객체로 바꾸어 반환
+     * @return MemberDto에 회원 정보를 담아 반환
      * @throws NicknameNotFoundException 닉네임이 존재하지 않을 경우
      */
-    public MemberInfoGetResponse getMemberInfo(String nickname) {
+    public MemberDto getMemberInfo(String nickname) {
         Member findMember = memeberRepository.findByNickname(nickname)
-                .orElseThrow(() -> new NicknameNotFoundException());
-        return MemberInfoGetResponse.from(findMember);
+                                    .orElseThrow(() -> new NicknameNotFoundException());
+        return MemberDto.from(findMember);
     }
 }

--- a/src/main/java/com/umc/withme/service/MemberService.java
+++ b/src/main/java/com/umc/withme/service/MemberService.java
@@ -2,9 +2,8 @@ package com.umc.withme.service;
 
 import com.umc.withme.domain.Member;
 import com.umc.withme.dto.member.MemberDto;
-import com.umc.withme.dto.member.MemberInfoGetResponse;
 import com.umc.withme.exception.member.NicknameNotFoundException;
-import com.umc.withme.repository.MemeberRepository;
+import com.umc.withme.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
-    private final MemeberRepository memeberRepository;
+    private final MemberRepository memberRepository;
 
     /**
      * DB에서 닉네임 중복여부 확인 후 결과를 컨트롤러에게 반환한다.
@@ -23,7 +22,7 @@ public class MemberService {
      * @return 중복인 경우 - true, 중복이 아닌 경우 - false
      */
     public boolean checkNicknameDuplication(String nickname) {
-        return memeberRepository.existsByNickname(nickname);
+        return memberRepository.existsByNickname(nickname);
     }
 
     /**
@@ -34,7 +33,7 @@ public class MemberService {
      * @throws NicknameNotFoundException 닉네임이 존재하지 않을 경우
      */
     public MemberDto getMemberInfo(String nickname) {
-        Member findMember = memeberRepository.findByNickname(nickname)
+        Member findMember = memberRepository.findByNickname(nickname)
                                     .orElseThrow(() -> new NicknameNotFoundException());
         return MemberDto.from(findMember);
     }


### PR DESCRIPTION
close #25

## 작업 사항

- 입력받은 닉네임을 가진 Member 객체를 DB에서 찾아 MemberInfoGetResponse라는 DTO로 변환하여 반환하는 API 구현
  - 만약, 닉네임을 가지는 회원이 존재하지 않을 경우 NicknameNotFoundException 에러 발생
- 이번에는 에러 처리를 잘 한 것 같다. 에러 발생 시 잘 처리되는 것을 확인함.
- Member 객체에 값을 넣을 때 validation을 처리하므로 MemberInfoGetResponse에 별다른 validation 처리를 하지 않았는데 필요한가 싶다.

## 참고 자료

- 참고자료 (링크 등)

## 체크리스트

- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?