### PR TITLE
회원 전체 조회 기능

### DIFF
--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -12,6 +12,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.constraints.NotBlank;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -52,5 +53,19 @@ public class MemberController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new DataResponse(response));
+    }
+
+    /**
+     * 전체 회원 조회 API
+     *
+     * @return 회원 목록을 DataResponse에 담아 반환
+     */
+    @GetMapping("/userss")
+    public ResponseEntity<DataResponse> getAllMemberInfo() {
+        List<MemberDto> memberList = memberService.getAllMemberInfo();
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new DataResponse(memberList));
     }
 }

--- a/src/main/java/com/umc/withme/repository/MemberRepository.java
+++ b/src/main/java/com/umc/withme/repository/MemberRepository.java
@@ -4,6 +4,7 @@ import com.umc.withme.domain.Member;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -24,4 +25,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
      */
     @EntityGraph(attributePaths = {"address"})
     Optional<Member> findByNickname(String nickname);
+
+    /**
+     * DB에서 모든 Member 객체들을 조회한다.
+     *
+     * @return Member 객체 리스트
+     */
+    @EntityGraph(attributePaths = {"address"})
+    List<Member> findAll();
 }

--- a/src/main/java/com/umc/withme/service/MemberService.java
+++ b/src/main/java/com/umc/withme/service/MemberService.java
@@ -1,12 +1,14 @@
 package com.umc.withme.service;
 
-import com.umc.withme.domain.Member;
 import com.umc.withme.dto.member.MemberDto;
 import com.umc.withme.exception.member.NicknameNotFoundException;
 import com.umc.withme.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -36,5 +38,17 @@ public class MemberService {
         return memberRepository.findByNickname(nickname)
                 .map(MemberDto::from)
                 .orElseThrow(NicknameNotFoundException::new);
+    }
+
+    /**
+     * DB에서 가져온 Member 객체들을 MemberDto로 변환해 컨트롤러에게 반환한다.
+     *
+     * @return MemberDto 객체 리스트
+     */
+    public List<MemberDto> getAllMemberInfo() {
+        return memberRepository.findAll()
+                .stream()
+                .map(MemberDto::from)
+                .collect(Collectors.toUnmodifiableList());
     }
 }


### PR DESCRIPTION
close #22

## 작업 사항

- 전체 회원에 대한 정보를 모두 가져오는 API 구현
- 조회만 하므로 `Collectors.toUnmodifiableList()`를 사용했다. null을 허용하지 않지만, 애초에 Member 필드에 데이터 추가 시 null 값 허용이 안되므로 따로 예외처리 하지 않았다.

## 참고 자료

- 참고자료 (링크 등)

## 체크리스트

- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?