### PR TITLE
Meet 생성 및 조회

### DIFF
--- a/src/main/java/com/umc/withme/domain/Meet.java
+++ b/src/main/java/com/umc/withme/domain/Meet.java
@@ -71,6 +71,25 @@ public class Meet extends BaseEntity {
 
     // 코드 추가는 여기에
 
+    // Meet 객체 정보를 출력하는 toString 함수
+    @Override
+    public String toString() {
+        return "Meet{" +
+                "id=" + id +
+                ", leaderName=" + leader.getNickname() +
+                ", category=" + category +
+                ", recruitStatus=" + recruitStatus +
+                ", meetStatus=" + meetStatus +
+                ", title='" + title + '\'' +
+                ", minPeople=" + minPeople +
+                ", maxPeople=" + maxPeople +
+                ", link='" + link + '\'' +
+                ", content='" + content + '\'' +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
+                '}';
+    }
+
     // Equals and HashCode
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/umc/withme/domain/MeetAddress.java
+++ b/src/main/java/com/umc/withme/domain/MeetAddress.java
@@ -1,0 +1,48 @@
+package com.umc.withme.domain;
+
+import com.umc.withme.domain.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class MeetAddress extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "meet_address_id")
+    private Long id;
+
+    @JoinColumn(name = "meet_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Meet meet;
+
+    @JoinColumn(name = "address_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Address address;
+
+    // Builder & Constructor
+    public MeetAddress(Meet meet, Address address){
+        this.meet = meet;
+        this.address = address;
+    }
+
+    // 코드 추가는 여기에
+
+    // Equals and HashCode
+    @Override
+    public boolean equals(Object o){
+        if (this == o) return true;
+        if (!(o instanceof MeetAddress)) return false;
+        MeetAddress that = (MeetAddress) o;
+        return this.getId() != null && this.getId().equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() { return Objects.hash(this.getId()); }
+}

--- a/src/main/java/com/umc/withme/dto/Meet/MeetAddressDto.java
+++ b/src/main/java/com/umc/withme/dto/Meet/MeetAddressDto.java
@@ -1,0 +1,58 @@
+package com.umc.withme.dto.Meet;
+
+import com.umc.withme.domain.Address;
+import com.umc.withme.domain.MeetAddress;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class MeetAddressDto {
+    private String sido;
+    private String sgg;
+
+    /**
+     * Address Entity인 Meet의 address를 입력받아
+     * 이를 MeatAddressDto로 변환해서 반환해주는 함수이다.
+     * @param address
+     * @return 변환된 MeetAddressDto
+     */
+    public static MeetAddressDto from(Address address){
+        return MeetAddressDto.builder()
+                .sido(address.getSido())
+                .sgg(address.getSgg())
+                .build();
+    }
+
+    /**
+     * MeetAddressDto 인스턴스를 Address Entity로 변환하여 반환해주는 함수이다.
+     * @return 변환된 Address Entity
+     */
+    public Address toEntity(){
+        return new Address(sido, sgg);
+    }
+
+    /**
+     * 입력받은 시도, 시군구 정보를 바탕으로 MeetAddressDto 인스턴스를 생성해 반환해주는 함수이다.
+     * @param sido
+     * @param sgg
+     * @return 생성한 MeetAddressDto 인스턴스
+     */
+    public static MeetAddressDto of(String sido, String sgg){
+        return MeetAddressDto.builder()
+                .sido(sido)
+                .sgg(sgg)
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return "MeetAddressDto{" +
+                "sido='" + sido + '\'' +
+                ", sgg='" + sgg + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/umc/withme/dto/Meet/MeetDto.java
+++ b/src/main/java/com/umc/withme/dto/Meet/MeetDto.java
@@ -1,7 +1,6 @@
 package com.umc.withme.dto.Meet;
 
 import com.umc.withme.domain.Meet;
-import com.umc.withme.domain.Member;
 import com.umc.withme.domain.constant.MeetCategory;
 import com.umc.withme.domain.constant.MeetStatus;
 import com.umc.withme.domain.constant.RecruitStatus;

--- a/src/main/java/com/umc/withme/dto/Meet/MeetDto.java
+++ b/src/main/java/com/umc/withme/dto/Meet/MeetDto.java
@@ -1,19 +1,30 @@
 package com.umc.withme.dto.Meet;
 
+import com.umc.withme.domain.Address;
 import com.umc.withme.domain.Meet;
+import com.umc.withme.domain.MeetAddress;
 import com.umc.withme.domain.Member;
 import com.umc.withme.domain.constant.MeetCategory;
 import com.umc.withme.domain.constant.MeetStatus;
 import com.umc.withme.domain.constant.RecruitStatus;
+import com.umc.withme.repository.MeetAddressRepository;
 import lombok.*;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 public class MeetDto {
 
+    @Autowired
+    private static MeetAddressRepository meetAddressRepository;
     private Long meetId;
     private MeetLeaderDto leader;  // 이 모임의 리더
+    private List<MeetAddressDto> addresses;  // 이 모임에 설정된 동네 리스트
     private MeetCategory meetCategory;
     private RecruitStatus recruitStatus;
     private MeetStatus meetStatus;
@@ -28,7 +39,7 @@ public class MeetDto {
 
     @Override
     public String toString() {
-        return "MeetDto{" +
+        String result = "MeetDto{" +
                 "meetId=" + meetId +
                 ", leaderName=" + leader.getNickName() +
                 ", meetCategory=" + meetCategory +
@@ -41,7 +52,21 @@ public class MeetDto {
                 ", content='" + content + '\'' +
                 ", startDate=" + startDate +
                 ", endDate=" + endDate +
-                '}';
+                "}\n";
+        result = result + "\n" + printAddress();
+        return result;
+    }
+
+    private String printAddress() {
+        String result = "";
+        if(getAddresses() == null || getAddresses().isEmpty()) return result;
+
+        result += "addresses={";
+        for (MeetAddressDto address : getAddresses()) {
+            result += address.toString() + ", ";
+        }
+        result += "}\n";
+        return result;
     }
 
     /**
@@ -52,9 +77,10 @@ public class MeetDto {
      * @return 변환된 MeetDto
      */
     public static MeetDto from(Meet meet){
-        return MeetDto.builder()
+        MeetDto result = MeetDto.builder()
                 .meetId(meet.getId())
                 .leader(MeetLeaderDto.from(meet.getLeader()))
+                .addresses(new ArrayList<>())
                 .meetCategory(meet.getCategory())
                 .recruitStatus(meet.getRecruitStatus())
                 .meetStatus(meet.getMeetStatus())
@@ -66,6 +92,7 @@ public class MeetDto {
                 .startDate(meet.getStartDate())
                 .endDate(meet.getEndDate())
                 .build();
+        return result;
     }
 
     /**
@@ -98,16 +125,19 @@ public class MeetDto {
      * @param content
      * @param startDate
      * @param endDate
+     * @param addresses (Meet의 동네 목록 리스트)
      * @return 생성된 MeetDto 인스턴스
      */
     public static MeetDto of(
             Long meetId, Member leader, MeetCategory meetCategory,
             RecruitStatus recruitStatus, MeetStatus meetStatus,
             String title, int minPeople, int maxPeople, String link,
-            String content, LocalDate startDate, LocalDate endDate){
-        return MeetDto.builder()
+            String content, LocalDate startDate, LocalDate endDate,
+            List<Address> addresses){
+        MeetDto meetDto = MeetDto.builder()
                 .meetId(meetId)
                 .leader(MeetLeaderDto.from(leader))
+                .addresses(new ArrayList<>())
                 .meetCategory(meetCategory)
                 .recruitStatus(recruitStatus)
                 .meetStatus(meetStatus)
@@ -119,5 +149,17 @@ public class MeetDto {
                 .startDate(startDate)
                 .endDate(endDate)
                 .build();
+        meetDto.setAddresses(addresses);
+        return meetDto;
+    }
+
+    /**
+     * 모임에 설정된 동네 목록을 설정하는 함수
+     * @param addresses
+     */
+    public void setAddresses(List<Address> addresses){
+        for (Address address : addresses) {
+            this.addresses.add(MeetAddressDto.from(address));
+        }
     }
 }

--- a/src/main/java/com/umc/withme/dto/Meet/MeetDto.java
+++ b/src/main/java/com/umc/withme/dto/Meet/MeetDto.java
@@ -1,0 +1,88 @@
+package com.umc.withme.dto.Meet;
+
+import com.umc.withme.domain.Meet;
+import com.umc.withme.domain.Member;
+import com.umc.withme.domain.constant.MeetCategory;
+import com.umc.withme.domain.constant.MeetStatus;
+import com.umc.withme.domain.constant.RecruitStatus;
+import lombok.*;
+
+import java.time.LocalDate;
+@Getter
+@Builder
+public class MeetDto {
+
+    private Long meetId;
+    private MeetLeaderDto leader;  // 이 모임의 리더
+    private MeetCategory meetCategory;
+    private RecruitStatus recruitStatus;
+    private MeetStatus meetStatus;
+
+    private String title;
+    private Integer minPeople;
+    private Integer maxPeople;
+    private String link;
+    private String content;
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    @Override
+    public String toString() {
+        return "MeetDto{" +
+                "meetId=" + meetId +
+                ", leaderName=" + leader.getNickName() +
+                ", meetCategory=" + meetCategory +
+                ", recruitStatus=" + recruitStatus +
+                ", meetStatus=" + meetStatus +
+                ", title='" + title + '\'' +
+                ", minPeople=" + minPeople +
+                ", maxPeople=" + maxPeople +
+                ", link='" + link + '\'' +
+                ", content='" + content + '\'' +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
+                '}';
+    }
+
+    /**
+     * Meet Entity를 입력받아
+     * MeetDto를 반환하는 함수
+     *
+     * @param 변환할 Meet Entity
+     * @return 변환된 MeetDto
+     */
+    public static MeetDto from(Meet meet){
+        return MeetDto.builder()
+                .meetId(meet.getId())
+                .leader(MeetLeaderDto.from(meet.getLeader()))
+                .meetCategory(meet.getCategory())
+                .recruitStatus(meet.getRecruitStatus())
+                .meetStatus(meet.getMeetStatus())
+                .title(meet.getTitle())
+                .minPeople(meet.getMinPeople())
+                .maxPeople(meet.getMaxPeople())
+                .link(meet.getLink())
+                .content(meet.getContent())
+                .startDate(meet.getStartDate())
+                .endDate(meet.getEndDate())
+                .build();
+    }
+
+    /**
+     * MeetDto 객체를 Meet Entity로 변환해서 반환해주는 함수이다.
+     * @return Meet Entity
+     */
+    public Meet toEntity(){
+        return Meet.builder()
+                .leader(this.getLeader().toEntity())
+                .category(this.getMeetCategory())
+                .title(this.getTitle())
+                .minPeople(this.getMinPeople())
+                .maxPeople(this.getMaxPeople())
+                .link(this.getLink())
+                .content(this.getContent())
+                .build();
+    }
+
+    // of 메소드는 추후에 제작 예정이다.
+}

--- a/src/main/java/com/umc/withme/dto/Meet/MeetDto.java
+++ b/src/main/java/com/umc/withme/dto/Meet/MeetDto.java
@@ -1,6 +1,7 @@
 package com.umc.withme.dto.Meet;
 
 import com.umc.withme.domain.Meet;
+import com.umc.withme.domain.Member;
 import com.umc.withme.domain.constant.MeetCategory;
 import com.umc.withme.domain.constant.MeetStatus;
 import com.umc.withme.domain.constant.RecruitStatus;
@@ -8,7 +9,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public class MeetDto {
 
     private Long meetId;
@@ -83,5 +84,40 @@ public class MeetDto {
                 .build();
     }
 
-    // of 메소드는 추후에 제작 예정이다.
+    /**
+     * MeetDto를 생성해서 반환해주는 함수이다.
+     * @param meetId
+     * @param leader
+     * @param meetCategory
+     * @param recruitStatus
+     * @param meetStatus
+     * @param title
+     * @param minPeople
+     * @param maxPeople
+     * @param link
+     * @param content
+     * @param startDate
+     * @param endDate
+     * @return 생성된 MeetDto 인스턴스
+     */
+    public static MeetDto of(
+            Long meetId, Member leader, MeetCategory meetCategory,
+            RecruitStatus recruitStatus, MeetStatus meetStatus,
+            String title, int minPeople, int maxPeople, String link,
+            String content, LocalDate startDate, LocalDate endDate){
+        return MeetDto.builder()
+                .meetId(meetId)
+                .leader(MeetLeaderDto.from(leader))
+                .meetCategory(meetCategory)
+                .recruitStatus(recruitStatus)
+                .meetStatus(meetStatus)
+                .title(title)
+                .minPeople(minPeople)
+                .maxPeople(maxPeople)
+                .link(link)
+                .content(content)
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/withme/dto/Meet/MeetLeaderDto.java
+++ b/src/main/java/com/umc/withme/dto/Meet/MeetLeaderDto.java
@@ -3,13 +3,14 @@ package com.umc.withme.dto.Meet;
 import com.umc.withme.domain.Member;
 import com.umc.withme.domain.TotalPoint;
 import com.umc.withme.domain.constant.Gender;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
 
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public class MeetLeaderDto {
 
     private String email;
@@ -48,6 +49,28 @@ public class MeetLeaderDto {
                 .gender(this.getGender())
                 .build();
     }
-    
-    // of 메소드는 추후에 제작 예정
+
+    /**
+     * 입력받은 파라미터를 바탕으로 MeetLeaderDto 인스턴스를 생성해 반환해주는 함수이다.
+     * @param email
+     * @param nickName
+     * @param phoneNumber
+     * @param birth
+     * @param gender
+     * @param totalPoint
+     * @return 생성한 MeetLeaderDto 인스턴스
+     */
+    public static MeetLeaderDto of(
+            String email, String nickName, String phoneNumber,
+            LocalDate birth, Gender gender, TotalPoint totalPoint
+    ){
+        return MeetLeaderDto.builder()
+                .email(email)
+                .nickName(nickName)
+                .phoneNumber(phoneNumber)
+                .birth(birth)
+                .gender(gender)
+                .totalPoint(totalPoint)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/withme/dto/Meet/MeetLeaderDto.java
+++ b/src/main/java/com/umc/withme/dto/Meet/MeetLeaderDto.java
@@ -1,0 +1,53 @@
+package com.umc.withme.dto.Meet;
+
+import com.umc.withme.domain.Member;
+import com.umc.withme.domain.TotalPoint;
+import com.umc.withme.domain.constant.Gender;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class MeetLeaderDto {
+
+    private String email;
+    private String nickName;
+    private String phoneNumber;
+    private LocalDate birth;
+    private Gender gender;
+    private TotalPoint totalPoint;
+
+    /**
+     * Member Entity인 Meet의 leader를 입력받아
+     * 이를 MeetLeaderDto로 변환해서 반환해주는 함수이다.
+     * @param  변환하려 하는 모임의 리더
+     * @return 변환된 MeetLeaderDto
+     */
+    public static MeetLeaderDto from(Member leader){
+        return MeetLeaderDto.builder()
+                .email(leader.getEmail())
+                .nickName(leader.getNickname())
+                .phoneNumber(leader.getPhoneNumber())
+                .birth(leader.getBirth())
+                .gender(leader.getGender())
+                .totalPoint(leader.getTotalPoint())
+                .build();
+    }
+
+    /**
+     * MeatLeaderDto 객체를 Member Entity 로 변환하여 반환해주는 함수이다.
+     * @return 변환된 Member Entity
+     */
+    public Member toEntity(){
+        return Member.builder()
+                .email(this.getEmail())
+                .phoneNumber(this.getPhoneNumber())
+                .birth(this.getBirth())
+                .gender(this.getGender())
+                .build();
+    }
+    
+    // of 메소드는 추후에 제작 예정
+}

--- a/src/main/java/com/umc/withme/repository/MeetAddressRepository.java
+++ b/src/main/java/com/umc/withme/repository/MeetAddressRepository.java
@@ -14,4 +14,11 @@ public interface MeetAddressRepository extends JpaRepository<MeetAddress, Long> 
      */
     List<MeetAddress> findAllByAddressId(Long addressId);
 
+    /**
+     * 해당 모임에 해당하는 MeetAddress 목록을 조회하는 함수
+     * @param meetId
+     * @return 해당 모임의 MeetAddress 리스트
+     */
+    List<MeetAddress> findAllByMeetId(Long meetId);
+
 }

--- a/src/main/java/com/umc/withme/repository/MeetAddressRepository.java
+++ b/src/main/java/com/umc/withme/repository/MeetAddressRepository.java
@@ -1,0 +1,17 @@
+package com.umc.withme.repository;
+
+import com.umc.withme.domain.MeetAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MeetAddressRepository extends JpaRepository<MeetAddress, Long> {
+
+    /**
+     * 해당 주소에 해당하는 MeetAddress 목록을 조회하는 함수
+     * @param addressId
+     * @return 해당 주소의 MeetAddress 리스트
+     */
+    List<MeetAddress> findAllByAddressId(Long addressId);
+
+}

--- a/src/main/java/com/umc/withme/repository/MeetRepository.java
+++ b/src/main/java/com/umc/withme/repository/MeetRepository.java
@@ -1,0 +1,7 @@
+package com.umc.withme.repository;
+
+import com.umc.withme.domain.Meet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeetRepository extends JpaRepository<Meet, Long> {
+}

--- a/src/main/java/com/umc/withme/repository/MeetRepository.java
+++ b/src/main/java/com/umc/withme/repository/MeetRepository.java
@@ -1,7 +1,16 @@
 package com.umc.withme.repository;
 
 import com.umc.withme.domain.Meet;
+import com.umc.withme.dto.Meet.MeetDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MeetRepository extends JpaRepository<Meet, Long> {
+    /**
+     * 제목으로 모임 조회
+     * @param 검색할 제목
+     * @return 반환할 Meet 목록
+     */
+    List<Meet> findMeetByTitle(String title);
 }

--- a/src/main/java/com/umc/withme/repository/MeetRepository.java
+++ b/src/main/java/com/umc/withme/repository/MeetRepository.java
@@ -1,8 +1,11 @@
 package com.umc.withme.repository;
 
+import com.umc.withme.domain.Address;
 import com.umc.withme.domain.Meet;
+import com.umc.withme.domain.constant.MeetCategory;
 import com.umc.withme.dto.Meet.MeetDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -10,7 +13,14 @@ public interface MeetRepository extends JpaRepository<Meet, Long> {
     /**
      * 제목으로 모임 조회
      * @param 검색할 제목
-     * @return 반환할 Meet 목록
+     * @return 해당 title을 가진 Meet 목록
      */
-    List<Meet> findMeetByTitle(String title);
+    List<Meet> findMeetsByTitle(String title);
+
+    /**
+     * 카테고리별로 모임 조회
+     * @param category
+     * @return 해당 카테고리인 Meet 목록
+     */
+    List<Meet> findMeetsByCategory(MeetCategory category);
 }

--- a/src/main/java/com/umc/withme/repository/MemberRepository.java
+++ b/src/main/java/com/umc/withme/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.umc.withme.repository;
+
+import com.umc.withme.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/umc/withme/service/MeetService.java
+++ b/src/main/java/com/umc/withme/service/MeetService.java
@@ -1,0 +1,43 @@
+package com.umc.withme.service;
+
+import com.umc.withme.domain.Meet;
+import com.umc.withme.dto.Meet.MeetDto;
+import com.umc.withme.repository.MeetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MeetService {
+
+    private final MeetRepository meetRepository;
+
+    /**
+     * 새로운 Meet 엔티티를 입력받아 repository에 저장한다.
+     * @param 저장할 Meet Entity
+     */
+    @Transactional
+    public void createMeet(Meet meet){
+        meetRepository.save(meet);
+    }
+
+    /**
+     * Meet 목록들을 전체 조회한다.
+     * @return 조회된 Meet 목록들의 리스트
+     */
+    public List<MeetDto> findMeets(){
+        List<Meet> meets = meetRepository.findAll();
+        List<MeetDto> result = meets.stream()
+                .map(m -> MeetDto.from(m))
+                .collect(Collectors.toList());
+        return result;
+    }
+}
+
+

--- a/src/main/java/com/umc/withme/service/MeetService.java
+++ b/src/main/java/com/umc/withme/service/MeetService.java
@@ -4,7 +4,6 @@ import com.umc.withme.domain.Meet;
 import com.umc.withme.dto.Meet.MeetDto;
 import com.umc.withme.repository.MeetRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/umc/withme/service/MeetService.java
+++ b/src/main/java/com/umc/withme/service/MeetService.java
@@ -52,6 +52,18 @@ public class MeetService {
             return meetDto;
         }else return null;
     }
+
+    /**
+     * 제목으로 모임을 조회해서 해당 제목을 가진 모임 DTO들의 목록을 반환한다.
+     * @param 검색할 제목
+     * @return 해당 제목의 모임 DTO 리스트
+     */
+    public List<MeetDto> findMeetsByTitle(String title){
+        List<Meet> meets = meetRepository.findMeetByTitle(title);
+        return meets.stream()
+                .map(meet -> MeetDto.from(meet))
+                .collect(Collectors.toList());
+    }
 }
 
 

--- a/src/main/java/com/umc/withme/service/MeetService.java
+++ b/src/main/java/com/umc/withme/service/MeetService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -36,6 +37,20 @@ public class MeetService {
                 .map(m -> MeetDto.from(m))
                 .collect(Collectors.toList());
         return result;
+    }
+
+    /**
+     * id로 모임을 조회해서 DTO로 변환하여 반환한다.
+     * @param 조회할 모임의 id
+     * @return 조회된 모임의 DTO
+     */
+    public MeetDto findMeetById(Long meetId){
+        Optional<Meet> optionalMeet = meetRepository.findById(meetId);
+        if(optionalMeet.isPresent()){
+            Meet findMeet = optionalMeet.get();
+            MeetDto meetDto = MeetDto.from(findMeet);
+            return meetDto;
+        }else return null;
     }
 }
 

--- a/src/main/java/com/umc/withme/service/MeetService.java
+++ b/src/main/java/com/umc/withme/service/MeetService.java
@@ -1,6 +1,7 @@
 package com.umc.withme.service;
 
 import com.umc.withme.domain.Meet;
+import com.umc.withme.domain.constant.MeetCategory;
 import com.umc.withme.dto.Meet.MeetDto;
 import com.umc.withme.repository.MeetRepository;
 import lombok.RequiredArgsConstructor;
@@ -59,7 +60,19 @@ public class MeetService {
      * @return 해당 제목의 모임 DTO 리스트
      */
     public List<MeetDto> findMeetsByTitle(String title){
-        List<Meet> meets = meetRepository.findMeetByTitle(title);
+        List<Meet> meets = meetRepository.findMeetsByTitle(title);
+        return meets.stream()
+                .map(meet -> MeetDto.from(meet))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 카테고리로 모임을 조회해서 해당 카테고리의 모임 DTO 목록을 반환한다.
+     * @param 조회할 카테고리명
+     * @return 해당 카테고리의 모임 DTO 리스트
+     */
+    public List<MeetDto> findMeetsByCategory(String category){
+        List<Meet> meets = meetRepository.findMeetsByCategory(MeetCategory.valueOf(category));
         return meets.stream()
                 .map(meet -> MeetDto.from(meet))
                 .collect(Collectors.toList());

--- a/src/main/java/com/umc/withme/service/MeetService.java
+++ b/src/main/java/com/umc/withme/service/MeetService.java
@@ -26,14 +26,16 @@ public class MeetService {
     private final AddressRepository addressRepository;
 
     /**
-     * 새로운 Meet 엔티티와 Address를 입력받아 모임 repository에 저장한다.
+     * 새로운 Meet 엔티티와 Address 목록을 입력받아 모임 repository에 저장한다.
      * 그리고 MeetAddress repository에 meet과 address를 연결해 저장한다.
-     * @param Meet Entity와 address Entity
+     * @param Meet Entity와 address Entity 목록
      */
     @Transactional
-    public void createMeet(Meet meet, Address address){
+    public void createMeet(Meet meet, List<Address> addresses){
         meetRepository.save(meet);
-        meetAddressRepository.save(new MeetAddress(meet, address));
+        for (Address address : addresses) {
+            meetAddressRepository.save(new MeetAddress(meet, address));
+        }
     }
 
     /**
@@ -45,6 +47,13 @@ public class MeetService {
         List<MeetDto> result = meets.stream()
                 .map(m -> MeetDto.from(m))
                 .collect(Collectors.toList());
+        for (MeetDto meetDto : result) {
+            List<MeetAddress> maList = meetAddressRepository.findAllByMeetId(meetDto.getMeetId());
+            List<Address> addresses = maList.stream()
+                    .map(ma -> ma.getAddress())
+                    .collect(Collectors.toList());
+            meetDto.setAddresses(addresses);
+        }
         return result;
     }
 
@@ -58,6 +67,13 @@ public class MeetService {
         if(optionalMeet.isPresent()){
             Meet findMeet = optionalMeet.get();
             MeetDto meetDto = MeetDto.from(findMeet);
+
+            List<MeetAddress> maList = meetAddressRepository.findAllByMeetId(meetDto.getMeetId());
+            List<Address> addresses = maList.stream()
+                    .map(ma -> ma.getAddress())
+                    .collect(Collectors.toList());
+            meetDto.setAddresses(addresses);
+
             return meetDto;
         }else return null;
     }
@@ -69,9 +85,18 @@ public class MeetService {
      */
     public List<MeetDto> findMeetsByTitle(String title){
         List<Meet> meets = meetRepository.findMeetsByTitle(title);
-        return meets.stream()
+        List<MeetDto> result = meets.stream()
                 .map(meet -> MeetDto.from(meet))
                 .collect(Collectors.toList());
+
+        for (MeetDto meetDto : result) {
+            List<MeetAddress> maList = meetAddressRepository.findAllByMeetId(meetDto.getMeetId());
+            List<Address> addresses = maList.stream()
+                    .map(ma -> ma.getAddress())
+                    .collect(Collectors.toList());
+            meetDto.setAddresses(addresses);
+        }
+        return result;
     }
 
     /**
@@ -81,9 +106,17 @@ public class MeetService {
      */
     public List<MeetDto> findMeetsByCategory(String category){
         List<Meet> meets = meetRepository.findMeetsByCategory(MeetCategory.valueOf(category));
-        return meets.stream()
+        List<MeetDto> result = meets.stream()
                 .map(meet -> MeetDto.from(meet))
                 .collect(Collectors.toList());
+        for (MeetDto meetDto : result) {
+            List<MeetAddress> maList = meetAddressRepository.findAllByMeetId(meetDto.getMeetId());
+            List<Address> addresses = maList.stream()
+                    .map(ma -> ma.getAddress())
+                    .collect(Collectors.toList());
+            meetDto.setAddresses(addresses);
+        }
+        return result;
     }
 
     /**
@@ -96,10 +129,17 @@ public class MeetService {
         List<Meet> meets = meetAddresses.stream()
                 .map(MeetAddress::getMeet)
                 .collect(Collectors.toList());
-        List<MeetDto> meetDtos = meets.stream()
+        List<MeetDto> result = meets.stream()
                 .map(meet -> MeetDto.from(meet))
                 .collect(Collectors.toList());
-        return meetDtos;
+        for (MeetDto meetDto : result) {
+            List<MeetAddress> maList = meetAddressRepository.findAllByMeetId(meetDto.getMeetId());
+            List<Address> addresses = maList.stream()
+                    .map(ma -> ma.getAddress())
+                    .collect(Collectors.toList());
+            meetDto.setAddresses(addresses);
+        }
+        return result;
     }
 }
 

--- a/src/test/java/com/umc/withme/repository/MeetRepositoryTest.java
+++ b/src/test/java/com/umc/withme/repository/MeetRepositoryTest.java
@@ -5,7 +5,6 @@ import com.umc.withme.domain.Meet;
 import com.umc.withme.domain.Member;
 import com.umc.withme.domain.constant.Gender;
 import com.umc.withme.domain.constant.MeetCategory;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/umc/withme/repository/MeetRepositoryTest.java
+++ b/src/test/java/com/umc/withme/repository/MeetRepositoryTest.java
@@ -5,6 +5,7 @@ import com.umc.withme.domain.Meet;
 import com.umc.withme.domain.Member;
 import com.umc.withme.domain.constant.Gender;
 import com.umc.withme.domain.constant.MeetCategory;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +14,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Meet - Repository Layer Test")
@@ -23,7 +26,33 @@ public class MeetRepositoryTest {
     @Autowired private MeetRepository meetRepository;
     @Autowired private MemberRepository memberRepository;
     @Autowired private AddressRepository addressRepository;
+    
+    @Test
+    public void 모임_목록_1개_조회() throws Exception{
+        //given
+        Address address = addressRepository.findBySidoAndSgg("서울특별시", "종로구").get();
 
+        Member member = createMember("1111@naver.com", "010-1111-1111", Gender.FEMALE, address);
+        memberRepository.save(member);
+
+        Meet saveMeet = createMeet(member, "title1", "www.1111.com", "content1");
+        meetRepository.save(saveMeet);
+        
+        //when
+        Optional<Meet> findMeet = meetRepository.findById(saveMeet.getId());
+
+        //then
+        if(findMeet.isPresent()){
+            Meet meet = findMeet.get();
+            assertThat(meet).isEqualTo(saveMeet);
+            assertThat(meet.getLeader()).isEqualTo(saveMeet.getLeader());
+            assertThat(meet.getTitle()).isEqualTo(saveMeet.getTitle());
+            assertThat(meet.getLink()).isEqualTo(saveMeet.getLink());
+            assertThat(meet.getContent()).isEqualTo(saveMeet.getContent());
+        }else
+            fail("모임이 조회되어야 합니다.");
+    }
+    
     @Test
     void 전체_모임_목록을_조회한다(){
 

--- a/src/test/java/com/umc/withme/repository/MeetRepositoryTest.java
+++ b/src/test/java/com/umc/withme/repository/MeetRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.umc.withme.repository;
+
+import com.umc.withme.domain.Address;
+import com.umc.withme.domain.Meet;
+import com.umc.withme.domain.Member;
+import com.umc.withme.domain.constant.Gender;
+import com.umc.withme.domain.constant.MeetCategory;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Meet - Repository Layer Test")
+@DataJpaTest
+@Transactional
+public class MeetRepositoryTest {
+    @Autowired private MeetRepository meetRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private AddressRepository addressRepository;
+
+    @Test
+    void 전체_모임_목록을_조회한다(){
+
+        // given
+        Address address1 = addressRepository.findBySidoAndSgg("서울특별시", "종로구").get();
+        Address address2 = addressRepository.findBySidoAndSgg("서울특별시", "강남구").get();
+        Address address3 = addressRepository.findBySidoAndSgg("부산광역시", "해운대구").get();
+
+        Member member1 = createMember("1111@naver.com", "010-1111-1111", Gender.FEMALE, address1);
+        Member member2 = createMember("2222@naver.com", "010-2222-2222", Gender.FEMALE, address2);
+        Member member3 = createMember("3333@naver.com", "010-3333-3333", Gender.MALE, address3);
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+        memberRepository.save(member3);
+
+        Meet meet1 = createMeet(member1, "title1", "www.1111.com", "content1");
+        Meet meet2 = createMeet(member2, "title2", "www.2222.com", "content2");
+        Meet meet3 = createMeet(member3, "title3", "www.3333.com", "content3");
+        meetRepository.save(meet1);
+        meetRepository.save(meet2);
+        meetRepository.save(meet3);
+
+        // when
+        List<Meet> meets = meetRepository.findAll();
+
+        // then
+        for (Meet meet : meets) {
+            System.out.println("meet = " + meet);
+        }
+
+        assertThat(meets.size()).isEqualTo(3);
+    }
+
+    private static Meet createMeet(Member member1, String title1, String link, String content1) {
+        return Meet.builder()
+                .leader(member1)
+                .category(MeetCategory.EXERCISE)
+                .title(title1)
+                .minPeople(3)
+                .maxPeople(5)
+                .link(link)
+                .content(content1)
+                .build();
+    }
+
+    private static Member createMember(String email, String phoneNumber, Gender gender, Address address) {
+
+        return Member.builder()
+                .address(address)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .birth(LocalDate.now())
+                .gender(gender)
+                .build();
+    }
+}

--- a/src/test/java/com/umc/withme/service/MeetServiceTest.java
+++ b/src/test/java/com/umc/withme/service/MeetServiceTest.java
@@ -42,7 +42,7 @@ class MeetServiceTest {
         Address address = addressRepository.findBySidoAndSgg("서울특별시", "종로구").get();
         Member member = createMember("AAAA@naver.com", "010-AAAA-AAAA", Gender.FEMALE, address);
         memberRepository.save(member);
-        Meet saveMeet = createMeet(member, "titleA", "www.AAAA.com", "contentA");
+        Meet saveMeet = createMeet(member,MeetCategory.HOBBY,  "titleA", "www.AAAA.com", "contentA");
         meetService.createMeet(saveMeet);
 
         //when
@@ -88,6 +88,21 @@ class MeetServiceTest {
         assertThat(findMeetDtos.get(1).getContent()).isEqualTo("content3");
     }
 
+    @Test
+    public void 카테고리로_모임_리스트_조회() throws Exception{
+        //given
+
+        //when
+        List<MeetDto> findMeetDtos = meetService.findMeetsByCategory("EXERCISE");
+
+        //then
+        assertThat(findMeetDtos.size()).isEqualTo(2);
+        assertThat(findMeetDtos.get(0).getMeetCategory()).isEqualTo(MeetCategory.EXERCISE);
+        assertThat(findMeetDtos.get(1).getMeetCategory()).isEqualTo(MeetCategory.EXERCISE);
+        assertThat(findMeetDtos.get(0).getContent()).isEqualTo("content1");
+        assertThat(findMeetDtos.get(1).getContent()).isEqualTo("content2");
+    }
+
     @BeforeEach
     public void setUp(){
         Address address1 = addressRepository.findBySidoAndSgg("서울특별시", "종로구").get();
@@ -101,18 +116,18 @@ class MeetServiceTest {
         memberRepository.save(member2);
         memberRepository.save(member3);
 
-        Meet meet1 = createMeet(member1, "titleA", "www.1111.com", "content1");
-        Meet meet2 = createMeet(member2, "titleB", "www.2222.com", "content2");
-        Meet meet3 = createMeet(member3, "titleA", "www.3333.com", "content3");
+        Meet meet1 = createMeet(member1, MeetCategory.EXERCISE, "titleA", "www.1111.com", "content1");
+        Meet meet2 = createMeet(member2, MeetCategory.EXERCISE, "titleB", "www.2222.com", "content2");
+        Meet meet3 = createMeet(member3, MeetCategory.HOBBY, "titleA", "www.3333.com", "content3");
         meetService.createMeet(meet1);
         meetService.createMeet(meet2);
         meetService.createMeet(meet3);
     }
 
-    private static Meet createMeet(Member member1, String title1, String link, String content1) {
+    private static Meet createMeet(Member member1, MeetCategory category, String title1, String link, String content1) {
         return Meet.builder()
                 .leader(member1)
-                .category(MeetCategory.EXERCISE)
+                .category(category)
                 .title(title1)
                 .minPeople(3)
                 .maxPeople(5)

--- a/src/test/java/com/umc/withme/service/MeetServiceTest.java
+++ b/src/test/java/com/umc/withme/service/MeetServiceTest.java
@@ -1,0 +1,90 @@
+package com.umc.withme.service;
+
+import com.umc.withme.domain.Address;
+import com.umc.withme.domain.Meet;
+import com.umc.withme.domain.Member;
+import com.umc.withme.domain.constant.Gender;
+import com.umc.withme.domain.constant.MeetCategory;
+import com.umc.withme.dto.Meet.MeetDto;
+import com.umc.withme.repository.AddressRepository;
+import com.umc.withme.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Meet - Service Layer Test")
+@SpringBootTest
+@Transactional
+class MeetServiceTest {
+
+    @Autowired
+    AddressRepository addressRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    MeetService meetService;
+
+    @Test
+    void 모임_전체_조회_기능_테스트() {
+        // given
+        Address address1 = addressRepository.findBySidoAndSgg("서울특별시", "종로구").get();
+        Address address2 = addressRepository.findBySidoAndSgg("서울특별시", "강남구").get();
+        Address address3 = addressRepository.findBySidoAndSgg("부산광역시", "해운대구").get();
+
+        Member member1 = createMember("1111@naver.com", "010-1111-1111", Gender.FEMALE, address1);
+        Member member2 = createMember("2222@naver.com", "010-2222-2222", Gender.FEMALE, address2);
+        Member member3 = createMember("3333@naver.com", "010-3333-3333", Gender.MALE, address3);
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+        memberRepository.save(member3);
+
+        Meet meet1 = createMeet(member1, "title1", "www.1111.com", "content1");
+        Meet meet2 = createMeet(member2, "title2", "www.2222.com", "content2");
+        Meet meet3 = createMeet(member3, "title3", "www.3333.com", "content3");
+        meetService.createMeet(meet1);
+        meetService.createMeet(meet2);
+        meetService.createMeet(meet3);
+
+        // when
+        List<MeetDto> meetDtos = meetService.findMeets();
+
+        // then
+        for (MeetDto meetDto : meetDtos) {
+            System.out.println("meetDto = " + meetDto);
+        }
+        assertThat(meetDtos.size()).isEqualTo(3);
+    }
+
+    private static Meet createMeet(Member member1, String title1, String link, String content1) {
+        return Meet.builder()
+                .leader(member1)
+                .category(MeetCategory.EXERCISE)
+                .title(title1)
+                .minPeople(3)
+                .maxPeople(5)
+                .link(link)
+                .content(content1)
+                .build();
+    }
+
+    private static Member createMember(String email, String phoneNumber, Gender gender, Address address) {
+
+        return Member.builder()
+                .address(address)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .birth(LocalDate.now())
+                .gender(gender)
+                .build();
+    }
+}

--- a/src/test/java/com/umc/withme/service/MeetServiceTest.java
+++ b/src/test/java/com/umc/withme/service/MeetServiceTest.java
@@ -93,6 +93,36 @@ class MeetServiceTest {
         assertThat(meetDtos.size()).isEqualTo(3);
     }
 
+    @Test
+    public void 제목_으로_모임_리스트_조회() throws Exception{
+        //given
+        Address address1 = addressRepository.findBySidoAndSgg("서울특별시", "종로구").get();
+        Address address2 = addressRepository.findBySidoAndSgg("서울특별시", "강남구").get();
+        Address address3 = addressRepository.findBySidoAndSgg("부산광역시", "해운대구").get();
+
+        Member member1 = createMember("1111@naver.com", "010-1111-1111", Gender.FEMALE, address1);
+        Member member2 = createMember("2222@naver.com", "010-2222-2222", Gender.FEMALE, address2);
+        Member member3 = createMember("3333@naver.com", "010-3333-3333", Gender.MALE, address3);
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+        memberRepository.save(member3);
+
+        Meet meet1 = createMeet(member1, "titleA", "www.1111.com", "content1");
+        Meet meet2 = createMeet(member2, "titleB", "www.2222.com", "content2");
+        Meet meet3 = createMeet(member3, "titleA", "www.3333.com", "content3");
+        meetService.createMeet(meet1);
+        meetService.createMeet(meet2);
+        meetService.createMeet(meet3);
+
+        //when
+        List<MeetDto> findMeetDtos = meetService.findMeetsByTitle("titleA");
+
+        //then
+        assertThat(findMeetDtos.size()).isEqualTo(2);
+        assertThat(findMeetDtos.get(0).getContent()).isEqualTo(meet1.getContent());
+        assertThat(findMeetDtos.get(1).getContent()).isEqualTo(meet3.getContent());
+    }
+
     private static Meet createMeet(Member member1, String title1, String link, String content1) {
         return Meet.builder()
                 .leader(member1)

--- a/src/test/java/com/umc/withme/service/MeetServiceTest.java
+++ b/src/test/java/com/umc/withme/service/MeetServiceTest.java
@@ -8,11 +8,9 @@ import com.umc.withme.domain.constant.MeetCategory;
 import com.umc.withme.dto.Meet.MeetDto;
 import com.umc.withme.repository.AddressRepository;
 import com.umc.withme.repository.MemberRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +18,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("Meet - Service Layer Test")
 @SpringBootTest

--- a/src/test/java/com/umc/withme/service/MeetServiceTest.java
+++ b/src/test/java/com/umc/withme/service/MeetServiceTest.java
@@ -43,7 +43,7 @@ class MeetServiceTest {
         Member member = createMember("AAAA@naver.com", "010-AAAA-AAAA", Gender.FEMALE, address);
         memberRepository.save(member);
         Meet saveMeet = createMeet(member,MeetCategory.HOBBY,  "titleA", "www.AAAA.com", "contentA");
-        meetService.createMeet(saveMeet);
+        meetService.createMeet(saveMeet, address);
 
         //when
         MeetDto findMeetDto = meetService.findMeetById(saveMeet.getId());
@@ -103,9 +103,22 @@ class MeetServiceTest {
         assertThat(findMeetDtos.get(1).getContent()).isEqualTo("content2");
     }
 
+    @Test
+    public void 동네로_모임_리스트_조회() throws Exception{
+        //given
+
+        //when
+        List<MeetDto> meetDtos = meetService.findMeetsByAddress(addressRepository.findBySidoAndSgg("서울특별시", "강남구").get());
+
+        //then
+        assertThat(meetDtos.size()).isEqualTo(2);
+        assertThat(meetDtos.get(0).getContent()).isEqualTo("content1");
+        assertThat(meetDtos.get(1).getContent()).isEqualTo("content2");
+    }
+
     @BeforeEach
     public void setUp(){
-        Address address1 = addressRepository.findBySidoAndSgg("서울특별시", "종로구").get();
+        Address address1 = addressRepository.findBySidoAndSgg("서울특별시", "강남구").get();
         Address address2 = addressRepository.findBySidoAndSgg("서울특별시", "강남구").get();
         Address address3 = addressRepository.findBySidoAndSgg("부산광역시", "해운대구").get();
 
@@ -119,9 +132,9 @@ class MeetServiceTest {
         Meet meet1 = createMeet(member1, MeetCategory.EXERCISE, "titleA", "www.1111.com", "content1");
         Meet meet2 = createMeet(member2, MeetCategory.EXERCISE, "titleB", "www.2222.com", "content2");
         Meet meet3 = createMeet(member3, MeetCategory.HOBBY, "titleA", "www.3333.com", "content3");
-        meetService.createMeet(meet1);
-        meetService.createMeet(meet2);
-        meetService.createMeet(meet3);
+        meetService.createMeet(meet1, address1);
+        meetService.createMeet(meet2, address2);
+        meetService.createMeet(meet3, address3);
     }
 
     private static Meet createMeet(Member member1, MeetCategory category, String title1, String link, String content1) {

--- a/src/test/java/com/umc/withme/service/MeetServiceTest.java
+++ b/src/test/java/com/umc/withme/service/MeetServiceTest.java
@@ -8,6 +8,7 @@ import com.umc.withme.domain.constant.MeetCategory;
 import com.umc.withme.dto.Meet.MeetDto;
 import com.umc.withme.repository.AddressRepository;
 import com.umc.withme.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,8 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 @DisplayName("Meet - Service Layer Test")
 @SpringBootTest
@@ -30,6 +34,33 @@ class MeetServiceTest {
     MemberRepository memberRepository;
     @Autowired
     MeetService meetService;
+
+    @Test
+    public void 모임_목록_1개_조회() throws Exception{
+        //given
+        Address address = addressRepository.findBySidoAndSgg("서울특별시", "종로구").get();
+
+        Member member = createMember("1111@naver.com", "010-1111-1111", Gender.FEMALE, address);
+        memberRepository.save(member);
+
+        Meet saveMeet = createMeet(member, "title1", "www.1111.com", "content1");
+        meetService.createMeet(saveMeet);
+
+        //when
+        MeetDto findMeetDto = meetService.findMeetById(saveMeet.getId());
+
+        //then
+        if(findMeetDto == null){
+            fail("모임 DTO가 조회되어야 한다.");
+        }else{
+            MeetDto saveMeetDto = MeetDto.from(saveMeet);
+            assertThat(findMeetDto.getLeader().getNickName()).isEqualTo(saveMeetDto.getLeader().getNickName());
+            assertThat(findMeetDto.getTitle()).isEqualTo(saveMeetDto.getTitle());
+            assertThat(findMeetDto.getLink()).isEqualTo(saveMeetDto.getLink());
+            assertThat(findMeetDto.getContent()).isEqualTo(saveMeetDto.getContent());
+        }
+    }
+
 
     @Test
     void 모임_전체_조회_기능_테스트() {

--- a/src/test/java/com/umc/withme/service/MeetServiceTest.java
+++ b/src/test/java/com/umc/withme/service/MeetServiceTest.java
@@ -9,6 +9,7 @@ import com.umc.withme.dto.Meet.MeetDto;
 import com.umc.withme.repository.AddressRepository;
 import com.umc.withme.repository.MemberRepository;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,11 +40,9 @@ class MeetServiceTest {
     public void 모임_목록_1개_조회() throws Exception{
         //given
         Address address = addressRepository.findBySidoAndSgg("서울특별시", "종로구").get();
-
-        Member member = createMember("1111@naver.com", "010-1111-1111", Gender.FEMALE, address);
+        Member member = createMember("AAAA@naver.com", "010-AAAA-AAAA", Gender.FEMALE, address);
         memberRepository.save(member);
-
-        Meet saveMeet = createMeet(member, "title1", "www.1111.com", "content1");
+        Meet saveMeet = createMeet(member, "titleA", "www.AAAA.com", "contentA");
         meetService.createMeet(saveMeet);
 
         //when
@@ -65,23 +64,6 @@ class MeetServiceTest {
     @Test
     void 모임_전체_조회_기능_테스트() {
         // given
-        Address address1 = addressRepository.findBySidoAndSgg("서울특별시", "종로구").get();
-        Address address2 = addressRepository.findBySidoAndSgg("서울특별시", "강남구").get();
-        Address address3 = addressRepository.findBySidoAndSgg("부산광역시", "해운대구").get();
-
-        Member member1 = createMember("1111@naver.com", "010-1111-1111", Gender.FEMALE, address1);
-        Member member2 = createMember("2222@naver.com", "010-2222-2222", Gender.FEMALE, address2);
-        Member member3 = createMember("3333@naver.com", "010-3333-3333", Gender.MALE, address3);
-        memberRepository.save(member1);
-        memberRepository.save(member2);
-        memberRepository.save(member3);
-
-        Meet meet1 = createMeet(member1, "title1", "www.1111.com", "content1");
-        Meet meet2 = createMeet(member2, "title2", "www.2222.com", "content2");
-        Meet meet3 = createMeet(member3, "title3", "www.3333.com", "content3");
-        meetService.createMeet(meet1);
-        meetService.createMeet(meet2);
-        meetService.createMeet(meet3);
 
         // when
         List<MeetDto> meetDtos = meetService.findMeets();
@@ -96,6 +78,18 @@ class MeetServiceTest {
     @Test
     public void 제목_으로_모임_리스트_조회() throws Exception{
         //given
+        
+        //when
+        List<MeetDto> findMeetDtos = meetService.findMeetsByTitle("titleA");
+
+        //then
+        assertThat(findMeetDtos.size()).isEqualTo(2);
+        assertThat(findMeetDtos.get(0).getContent()).isEqualTo("content1");
+        assertThat(findMeetDtos.get(1).getContent()).isEqualTo("content3");
+    }
+
+    @BeforeEach
+    public void setUp(){
         Address address1 = addressRepository.findBySidoAndSgg("서울특별시", "종로구").get();
         Address address2 = addressRepository.findBySidoAndSgg("서울특별시", "강남구").get();
         Address address3 = addressRepository.findBySidoAndSgg("부산광역시", "해운대구").get();
@@ -113,14 +107,6 @@ class MeetServiceTest {
         meetService.createMeet(meet1);
         meetService.createMeet(meet2);
         meetService.createMeet(meet3);
-
-        //when
-        List<MeetDto> findMeetDtos = meetService.findMeetsByTitle("titleA");
-
-        //then
-        assertThat(findMeetDtos.size()).isEqualTo(2);
-        assertThat(findMeetDtos.get(0).getContent()).isEqualTo(meet1.getContent());
-        assertThat(findMeetDtos.get(1).getContent()).isEqualTo(meet3.getContent());
     }
 
     private static Meet createMeet(Member member1, String title1, String link, String content1) {

--- a/src/test/java/com/umc/withme/service/MeetServiceTest.java
+++ b/src/test/java/com/umc/withme/service/MeetServiceTest.java
@@ -43,7 +43,7 @@ class MeetServiceTest {
         Member member = createMember("AAAA@naver.com", "010-AAAA-AAAA", Gender.FEMALE, address);
         memberRepository.save(member);
         Meet saveMeet = createMeet(member,MeetCategory.HOBBY,  "titleA", "www.AAAA.com", "contentA");
-        meetService.createMeet(saveMeet, address);
+        meetService.createMeet(saveMeet, List.of(address));
 
         //when
         MeetDto findMeetDto = meetService.findMeetById(saveMeet.getId());
@@ -57,6 +57,8 @@ class MeetServiceTest {
             assertThat(findMeetDto.getTitle()).isEqualTo(saveMeetDto.getTitle());
             assertThat(findMeetDto.getLink()).isEqualTo(saveMeetDto.getLink());
             assertThat(findMeetDto.getContent()).isEqualTo(saveMeetDto.getContent());
+
+            System.out.println("findMeetDto = " + findMeetDto);
         }
     }
 
@@ -132,9 +134,9 @@ class MeetServiceTest {
         Meet meet1 = createMeet(member1, MeetCategory.EXERCISE, "titleA", "www.1111.com", "content1");
         Meet meet2 = createMeet(member2, MeetCategory.EXERCISE, "titleB", "www.2222.com", "content2");
         Meet meet3 = createMeet(member3, MeetCategory.HOBBY, "titleA", "www.3333.com", "content3");
-        meetService.createMeet(meet1, address1);
-        meetService.createMeet(meet2, address2);
-        meetService.createMeet(meet3, address3);
+        meetService.createMeet(meet1, List.of(address1));
+        meetService.createMeet(meet2, List.of(address2));
+        meetService.createMeet(meet3, List.of(address3));
     }
 
     private static Meet createMeet(Member member1, MeetCategory category, String title1, String link, String content1) {


### PR DESCRIPTION
## 작업 사항
- 모임글 Service 생성 및 전체 조회 구현 및 테스트 
- 모임글 제목으로 구현 및 테스트
- 모임글 카테고리로 조회 기능 구현
- DTO builder 접근제어자를 private으로 변경하고 of 메소드를 추가구현함
- 모임글 내동네로 조회 기능 구현
- MeetDto 에 동네 목록 넣기

MeetService의 입력 파라미터가 현재 DTO가 아니라 엔티티인데 이거는 머지해서 MemberDto 코드 받아오면 그때 수정하려고 합니다!

## 참고 자료

- 참고자료 (링크 등)

## 체크리스트
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?