### PR TITLE
회원가입 추가 로직 구현 (폰 번호, 지역 설정)

### DIFF
--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -1,20 +1,25 @@
 package com.umc.withme.controller;
 
+import com.umc.withme.dto.common.BaseResponse;
 import com.umc.withme.dto.common.DataResponse;
-import com.umc.withme.dto.member.MemberDto;
-import com.umc.withme.dto.member.MemberInfoGetResponse;
-import com.umc.withme.dto.member.NicknameDuplicationCheckResponse;
+import com.umc.withme.dto.member.*;
+import com.umc.withme.security.WithMeAppPrinciple;
 import com.umc.withme.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 
 @RestController
@@ -56,5 +61,47 @@ public class MemberController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new DataResponse<>(response));
+    }
+
+    @Operation(
+            summary = "회원 폰 번호 설정/재설정",
+            description = "<p><code>memberId</code>에 해당하는 회원의 폰 번호를 request body의 <code>phoneNumber</code>로 설정합니다.</p>",
+            security = @SecurityRequirement(name = "access-token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "404", description = "1401: <code>email</code>에 해당하는 회원이 없는 경우", content = @Content)
+    })
+    @PatchMapping("/user/phone-number")
+    public ResponseEntity<BaseResponse> updateMemberPhoneNumber(
+            @Parameter(hidden = true) @AuthenticationPrincipal WithMeAppPrinciple principle,
+            @Valid @RequestBody MemberPhoneNumberUpdateRequest request
+    ) {
+        memberService.updateMemberPhoneNumber(principle.getUsername(), request.getPhoneNumber());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new BaseResponse(true));
+    }
+
+    @Operation(
+            summary = "회원 주소 설정/재설정",
+            description = "<p><code>memberId</code>에 해당하는 회원의 주소 정보를 request body의 <code>sido</code>, <code>sgg</code>로 설정합니다.</p>",
+            security = @SecurityRequirement(name = "access-token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "404", description = "1401: <code>email</code>에 해당하는 회원이 없는 경우", content = @Content)
+    })
+    @PatchMapping("/user/address")
+    public ResponseEntity<BaseResponse> updateMemberAddress(
+            @Parameter(hidden = true) @AuthenticationPrincipal WithMeAppPrinciple principle,
+            @Valid @RequestBody MemberAddressUpdateRequest request
+    ) {
+        memberService.updateMemberAddress(principle.getUsername(), request.getSido(), request.getSgg());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new BaseResponse(true));
     }
 }

--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.ConstraintViolationException;
 import javax.validation.constraints.NotBlank;
 
 @RestController
@@ -28,32 +29,32 @@ public class MemberController {
      * 닉네임 중복 조회를 하는 API
      *
      * @param nickname
-     * @return 중복 여부를 DataResponse에 담아 반환
+     * @return 중복 여부를 {@link NicknameDuplicationCheckResponse}에 담아 {@link DataResponse}로 반환
      * @throws ConstraintViolationException 닉네임이 공백인 경우
      */
     // TODO: Swagger 문서에 적용
     @GetMapping("/check/duplicate")
-    public ResponseEntity<DataResponse> checkNicknameDuplicate(@RequestParam @NotBlank String nickname) {
+    public ResponseEntity<DataResponse<NicknameDuplicationCheckResponse>> checkNicknameDuplicate(@RequestParam @NotBlank String nickname) {
         NicknameDuplicationCheckResponse response = NicknameDuplicationCheckResponse.of(memberService.checkNicknameDuplication(nickname));
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(new DataResponse(response));
+                .body(new DataResponse<>(response));
     }
 
     /**
      * 특정 닉네임을 가지는 회원 정보를 조회하는 API
      *
      * @param nickname
-     * @return MemberInfoGetResponse에 회원 정보를 담아 DataResponse로 반환
+     * @return {@link MemberInfoGetResponse}에 회원 정보를 담아 {@link DataResponse}로 반환
      */
     @GetMapping("/users")
-    public ResponseEntity<DataResponse> getMemberInfo(@RequestParam @NotBlank String nickname) {
+    public ResponseEntity<DataResponse<MemberInfoGetResponse>> getMemberInfo(@RequestParam @NotBlank String nickname) {
         MemberDto memberDto = memberService.findMemberByNickname(nickname);
         MemberInfoGetResponse response = MemberInfoGetResponse.from(memberDto);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(new DataResponse(response));
+                .body(new DataResponse<>(response));
     }
 }

--- a/src/main/java/com/umc/withme/domain/Member.java
+++ b/src/main/java/com/umc/withme/domain/Member.java
@@ -3,10 +3,7 @@ package com.umc.withme.domain;
 import com.umc.withme.domain.common.BaseTimeEntity;
 import com.umc.withme.domain.constant.Gender;
 import com.umc.withme.domain.constant.RoleType;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.util.Objects;
@@ -21,6 +18,7 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_id")
     private Long id;
 
+    @Setter
     @JoinColumn(name = "address_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Address address;
@@ -35,6 +33,7 @@ public class Member extends BaseTimeEntity {
     @Column(unique = true, nullable = false)
     private String password;
 
+    @Setter
     @Column(unique = true)
     private String phoneNumber;
 

--- a/src/main/java/com/umc/withme/dto/common/BaseResponse.java
+++ b/src/main/java/com/umc/withme/dto/common/BaseResponse.java
@@ -1,5 +1,6 @@
 package com.umc.withme.dto.common;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,5 +8,6 @@ import lombok.Getter;
 @Getter
 public class BaseResponse {
 
+    @Schema(example = "true", description = "요청 처리 성공 시 true, 실패 시 false")
     private boolean isSuccess;
 }

--- a/src/main/java/com/umc/withme/dto/common/DataResponse.java
+++ b/src/main/java/com/umc/withme/dto/common/DataResponse.java
@@ -1,10 +1,12 @@
 package com.umc.withme.dto.common;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class DataResponse<T> extends BaseResponse{
 
+    @Schema(description = "응답 데이터")
     private T data;
 
     public DataResponse(T data) {

--- a/src/main/java/com/umc/withme/dto/common/ErrorResponse.java
+++ b/src/main/java/com/umc/withme/dto/common/ErrorResponse.java
@@ -1,13 +1,15 @@
 package com.umc.withme.dto.common;
 
-import com.umc.withme.dto.common.BaseResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class ErrorResponse extends BaseResponse {
 
+    @Schema(example = "0", description = "UMC Server 팀에서 정한 내부적인 error code")
     private int errorCode;
 
+    @Schema(example = "Error message", description = "에러 상황에 대한 설명")
     private String errorMessage;
 
     public ErrorResponse(int errorCode, String errorMessage) {

--- a/src/main/java/com/umc/withme/dto/member/MemberAddressUpdateRequest.java
+++ b/src/main/java/com/umc/withme/dto/member/MemberAddressUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.umc.withme.dto.member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberAddressUpdateRequest {
+
+    @Schema(example = "서울특별시", description = "시/도")
+    @NotBlank
+    private String sido;
+
+    @Schema(example = "강남구", description = "시/군/구")
+    @NotBlank
+    private String sgg;
+}

--- a/src/main/java/com/umc/withme/dto/member/MemberPhoneNumberUpdateRequest.java
+++ b/src/main/java/com/umc/withme/dto/member/MemberPhoneNumberUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.umc.withme.dto.member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberPhoneNumberUpdateRequest {
+
+    @Schema(example = "010-1234-5678", description = "설정할 폰 번호")
+    @NotBlank
+    @Pattern(regexp = "[0-9]{3}-+[0-9]{4}-+[0-9]{4}", message = "전화번호는 010-XXXX-XXXX 형태로 전달해주세요.")
+    private String phoneNumber;
+}


### PR DESCRIPTION
This closes #54

## 작업 사항
- #29 에서 구현한 로그인 과정 중 회원가입 로직에서 폰 번호와 주소를 받는 부분이 구현되지 않았다. 이 때문에 이 PR을 통해 회원가입 로직의 나머지 구현인 폰 번호 설정, 주소 설정 기능을 구현하였다.

## 참고 자료
- None

## 체크리스트
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?