### PR TITLE
회원 API 수정

### DIFF
--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -30,14 +30,12 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    /**
-     * 닉네임 중복 조회를 하는 API
-     *
-     * @param nickname
-     * @return 중복 여부를 {@link NicknameDuplicationCheckResponse}에 담아 {@link DataResponse}로 반환
-     * @throws ConstraintViolationException 닉네임이 공백인 경우
-     */
-    // TODO: Swagger 문서에 적용
+    @Operation(
+            summary = "닉네임 중복 조회",
+            description = "<p>해당 <code>nickname</code>이 다른 사용자가 사용 중인지 확인한다." +
+                    "반환 값이 true이면 이미 사용 중인 닉네임이고, false이면 사용 중이지 않는 닉네임이다.</p>",
+            security = @SecurityRequirement(name = "access-token")
+    )
     @GetMapping("/members/check")
     public ResponseEntity<DataResponse<NicknameDuplicationCheckResponse>> checkNicknameDuplicate(@RequestParam @NotBlank String nickname) {
         NicknameDuplicationCheckResponse response = NicknameDuplicationCheckResponse.of(memberService.checkNicknameDuplication(nickname));
@@ -47,12 +45,15 @@ public class MemberController {
                 .body(new DataResponse<>(response));
     }
 
-    /**
-     * 특정 닉네임을 가지는 회원 정보를 조회하는 API
-     *
-     * @param nickname
-     * @return {@link MemberInfoGetResponse}에 회원 정보를 담아 {@link DataResponse}로 반환
-     */
+    @Operation(
+            summary = "특정 닉네임을 가지는 회원 정보 조회",
+            description = "<p>해당 <code>nickname</code>을 가지는 사용자의 정보를 조회한다.</p>",
+            security = @SecurityRequirement(name = "access-token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "404", description = "1400: <code>nickname</code>을 가지는 회원이 없는 경우", content = @Content)
+    })
     @GetMapping("/members")
     public ResponseEntity<DataResponse<MemberInfoGetResponse>> getMemberInfo(@RequestParam @NotBlank String nickname) {
         MemberDto memberDto = memberService.findMemberByNickname(nickname);

--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -32,7 +32,7 @@ public class MemberController {
 
     @Operation(
             summary = "닉네임 중복 조회",
-            description = "<p>해당 <code>nickname</code>이 다른 사용자가 사용 중인지 확인한다." +
+            description = "<p>해당 <code>nickname</code>이 다른 사용자가 사용 중인지 확인한다. " +
                     "반환 값이 true이면 이미 사용 중인 닉네임이고, false이면 사용 중이지 않는 닉네임이다.</p>",
             security = @SecurityRequirement(name = "access-token")
     )

--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -38,7 +38,7 @@ public class MemberController {
      * @throws ConstraintViolationException 닉네임이 공백인 경우
      */
     // TODO: Swagger 문서에 적용
-    @GetMapping("/check/duplicate")
+    @GetMapping("/members/check")
     public ResponseEntity<DataResponse<NicknameDuplicationCheckResponse>> checkNicknameDuplicate(@RequestParam @NotBlank String nickname) {
         NicknameDuplicationCheckResponse response = NicknameDuplicationCheckResponse.of(memberService.checkNicknameDuplication(nickname));
 
@@ -53,7 +53,7 @@ public class MemberController {
      * @param nickname
      * @return {@link MemberInfoGetResponse}에 회원 정보를 담아 {@link DataResponse}로 반환
      */
-    @GetMapping("/users")
+    @GetMapping("/members")
     public ResponseEntity<DataResponse<MemberInfoGetResponse>> getMemberInfo(@RequestParam @NotBlank String nickname) {
         MemberDto memberDto = memberService.findMemberByNickname(nickname);
         MemberInfoGetResponse response = MemberInfoGetResponse.from(memberDto);

--- a/src/main/java/com/umc/withme/dto/address/AddressDto.java
+++ b/src/main/java/com/umc/withme/dto/address/AddressDto.java
@@ -1,6 +1,7 @@
 package com.umc.withme.dto.address;
 
 import com.umc.withme.domain.Address;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,7 +10,10 @@ import lombok.Getter;
 @Getter
 public class AddressDto {
 
+    @Schema(example = "서울특별시", description = "회원 주소의 광역시·도")
     private String sido;
+
+    @Schema(example = "강남구", description = "회원 주소의 시·군·자치구")
     private String sgg;
 
     public static AddressDto of(String sido, String sgg) {

--- a/src/main/java/com/umc/withme/dto/member/MemberInfoGetResponse.java
+++ b/src/main/java/com/umc/withme/dto/member/MemberInfoGetResponse.java
@@ -2,6 +2,7 @@ package com.umc.withme.dto.member;
 
 import com.umc.withme.domain.constant.Gender;
 import com.umc.withme.dto.address.AddressDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,10 +11,19 @@ import lombok.Getter;
 @Getter
 public class MemberInfoGetResponse {
 
+    @Schema(example = "park", description = "회원의 닉네임")
     private String nickname;
+
+    @Schema(example = "010-1234-5678", description = "회원의 핸드폰 번호")
     private String phoneNumber;
+
+    @Schema(example = "20", description = "회원의 연령대")
     private Integer ageRange;
+
+    @Schema(example = "FEMALE", description = "회원의 성별")
     private Gender gender;
+
+    @Schema(description = "회원의 주소")
     private AddressDto address;
 
     public static MemberInfoGetResponse from(MemberDto dto) {

--- a/src/main/java/com/umc/withme/dto/member/NicknameDuplicationCheckResponse.java
+++ b/src/main/java/com/umc/withme/dto/member/NicknameDuplicationCheckResponse.java
@@ -1,5 +1,6 @@
 package com.umc.withme.dto.member;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import lombok.Getter;
 @Getter
 public class NicknameDuplicationCheckResponse {
 
+    @Schema(example = "true", description = "닉네임 중복 여부")
     private boolean isDuplicated;
 
     public static NicknameDuplicationCheckResponse of(boolean isDuplicated) {


### PR DESCRIPTION
close #36 

## 작업 사항
1. `닉네임이 사용 중인지 체크하는 API` 
2. `특정 닉네임을 가지는 회원 정보를 조회하는 API`
- 회원 API swagger 문서화 추가
- API 경로 수정
  - /api/check/duplicate => /api/members/check
  - /api/users => /api/members
> 입력 값이 id가 아닌 nickname이라 RequestParam이 더 명확해보이는데 PathVariable을 사용하는 것이 더 좋을 것 같으면 말씀해주세요!

## 참고 자료

- 참고자료 (링크 등)

## 체크리스트

- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?