### PR TITLE
회원 닉네임 설정 API

### DIFF
--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -23,7 +23,7 @@ import javax.validation.constraints.NotBlank;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/members")
 @Validated
 public class MemberController {
 
@@ -35,7 +35,7 @@ public class MemberController {
                     "반환 값이 true이면 이미 사용 중인 닉네임이고, false이면 사용 중이지 않는 닉네임이다.</p>",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/members/check")
+    @GetMapping("/check")
     public ResponseEntity<DataResponse<NicknameDuplicationCheckResponse>> checkNicknameDuplicate(@RequestParam @NotBlank String nickname) {
         NicknameDuplicationCheckResponse response = NicknameDuplicationCheckResponse.of(memberService.checkNicknameDuplication(nickname));
 
@@ -53,7 +53,7 @@ public class MemberController {
             @ApiResponse(responseCode = "200", description = "Success"),
             @ApiResponse(responseCode = "404", description = "1400: <code>nickname</code>을 가지는 회원이 없는 경우", content = @Content)
     })
-    @GetMapping("/members")
+    @GetMapping
     public ResponseEntity<DataResponse<MemberInfoGetResponse>> getMemberInfo(@RequestParam @NotBlank String nickname) {
         MemberDto memberDto = memberService.findMemberByNickname(nickname);
         MemberInfoGetResponse response = MemberInfoGetResponse.from(memberDto);
@@ -68,7 +68,7 @@ public class MemberController {
             description = "<p>로그인 중인 회원의 폰 번호를 request body의 <code>phoneNumber</code>로 설정합니다.</p>",
             security = @SecurityRequirement(name = "access-token")
     )
-    @PatchMapping("/user/phone-number")
+    @PatchMapping("/phone-number")
     public ResponseEntity<BaseResponse> updateMemberPhoneNumber(
             @Parameter(hidden = true) @AuthenticationPrincipal WithMeAppPrinciple principle,
             @Valid @RequestBody MemberPhoneNumberUpdateRequest request
@@ -85,7 +85,7 @@ public class MemberController {
             description = "<p>로그인 중인 회원의 주소 정보를 request body의 <code>sido</code>, <code>sgg</code>로 설정합니다.</p>",
             security = @SecurityRequirement(name = "access-token")
     )
-    @PatchMapping("/user/address")
+    @PatchMapping("/address")
     public ResponseEntity<BaseResponse> updateMemberAddress(
             @Parameter(hidden = true) @AuthenticationPrincipal WithMeAppPrinciple principle,
             @Valid @RequestBody MemberAddressUpdateRequest request

--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -18,7 +18,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.ConstraintViolationException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 
@@ -66,13 +65,9 @@ public class MemberController {
 
     @Operation(
             summary = "회원 폰 번호 설정/재설정",
-            description = "<p><code>memberId</code>에 해당하는 회원의 폰 번호를 request body의 <code>phoneNumber</code>로 설정합니다.</p>",
+            description = "<p>로그인 중인 회원의 폰 번호를 request body의 <code>phoneNumber</code>로 설정합니다.</p>",
             security = @SecurityRequirement(name = "access-token")
     )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Success"),
-            @ApiResponse(responseCode = "404", description = "1401: <code>email</code>에 해당하는 회원이 없는 경우", content = @Content)
-    })
     @PatchMapping("/user/phone-number")
     public ResponseEntity<BaseResponse> updateMemberPhoneNumber(
             @Parameter(hidden = true) @AuthenticationPrincipal WithMeAppPrinciple principle,
@@ -87,13 +82,9 @@ public class MemberController {
 
     @Operation(
             summary = "회원 주소 설정/재설정",
-            description = "<p><code>memberId</code>에 해당하는 회원의 주소 정보를 request body의 <code>sido</code>, <code>sgg</code>로 설정합니다.</p>",
+            description = "<p>로그인 중인 회원의 주소 정보를 request body의 <code>sido</code>, <code>sgg</code>로 설정합니다.</p>",
             security = @SecurityRequirement(name = "access-token")
     )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Success"),
-            @ApiResponse(responseCode = "404", description = "1401: <code>email</code>에 해당하는 회원이 없는 경우", content = @Content)
-    })
     @PatchMapping("/user/address")
     public ResponseEntity<BaseResponse> updateMemberAddress(
             @Parameter(hidden = true) @AuthenticationPrincipal WithMeAppPrinciple principle,

--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -81,6 +81,27 @@ public class MemberController {
     }
 
     @Operation(
+            summary = "회원 닉네임 설정/재설정",
+            description = "<p>로그인 중인 회원의 닉네임을 request body의 <code>nickname</code>로 설정합니다.</p>",
+            security = @SecurityRequirement(name = "access-token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "409", description = "1402: 이미 사용중인 닉네임인 경우(닉네임 중복)", content = @Content)
+    })
+    @PatchMapping("/nickname")
+    public ResponseEntity<BaseResponse> updateMemberNickname(
+            @Parameter(hidden = true) @AuthenticationPrincipal WithMeAppPrinciple principle,
+            @Valid @RequestBody MemberNicknameUpdateRequest request
+    ) {
+        memberService.updateMemberNickname(principle.getUsername(), request.getNickname());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new BaseResponse(true));
+    }
+
+    @Operation(
             summary = "회원 주소 설정/재설정",
             description = "<p>로그인 중인 회원의 주소 정보를 request body의 <code>sido</code>, <code>sgg</code>로 설정합니다.</p>",
             security = @SecurityRequirement(name = "access-token")

--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -87,7 +87,7 @@ public class MemberController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Success"),
-            @ApiResponse(responseCode = "409", description = "1402: 이미 사용중인 닉네임인 경우(닉네임 중복)", content = @Content)
+            @ApiResponse(responseCode = "409", description = "1403: 이미 사용중인 닉네임인 경우(닉네임 중복)", content = @Content)
     })
     @PatchMapping("/nickname")
     public ResponseEntity<BaseResponse> updateMemberNickname(

--- a/src/main/java/com/umc/withme/domain/Member.java
+++ b/src/main/java/com/umc/withme/domain/Member.java
@@ -37,6 +37,7 @@ public class Member extends BaseTimeEntity {
     @Column(unique = true)
     private String phoneNumber;
 
+    @Setter
     @Column(unique = true, nullable = false)
     private String nickname;
 

--- a/src/main/java/com/umc/withme/dto/member/MemberNicknameUpdateRequest.java
+++ b/src/main/java/com/umc/withme/dto/member/MemberNicknameUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.umc.withme.dto.member;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberNicknameUpdateRequest {
+
+    // TODO: 추후 닉네임 최대/최소 글자수 반영 필요
+    @NotBlank
+    private String nickname;
+}

--- a/src/main/java/com/umc/withme/exception/ExceptionType.java
+++ b/src/main/java/com/umc/withme/exception/ExceptionType.java
@@ -5,6 +5,7 @@ import com.umc.withme.exception.auth.KakaoOAuthUnauthorizedException;
 import com.umc.withme.exception.common.CustomException;
 import com.umc.withme.exception.meet.MeetIdNotFoundException;
 import com.umc.withme.exception.member.EmailNotFoundException;
+import com.umc.withme.exception.member.NicknameDuplicateException;
 import com.umc.withme.exception.member.NicknameNotFoundException;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -43,6 +44,7 @@ public enum ExceptionType {
     // Member
     NICKNAME_NOT_FOUND_EXCEPTION(1400, "해당 닉네임을 가지는 회원이 없습니다.", NicknameNotFoundException.class),
     EMAIL_NOT_FOUND_EXCEPTION(1401, "해당 이메일을 갖는 회원을 찾을 수 없습니다.", EmailNotFoundException.class),
+    NICKNAME_DUPLICATE_EXCEPTION(1402, "이미 사용중인 닉네임입니다.", NicknameDuplicateException.class),
 
     // Meet
     MEET_ID_NOT_FOUND_EXCEPTION(2400, "해당 id를 가지는 모임을 찾을 수 없습니다.", MeetIdNotFoundException.class),

--- a/src/main/java/com/umc/withme/exception/common/ConflictException.java
+++ b/src/main/java/com/umc/withme/exception/common/ConflictException.java
@@ -1,0 +1,14 @@
+package com.umc.withme.exception.common;
+
+import org.springframework.http.HttpStatus;
+
+public class ConflictException extends CustomException {
+
+    public ConflictException() {
+        super(HttpStatus.CONFLICT);
+    }
+
+    public ConflictException(String optionalMessage) {
+        super(HttpStatus.CONFLICT, optionalMessage);
+    }
+}

--- a/src/main/java/com/umc/withme/exception/member/NicknameDuplicateException.java
+++ b/src/main/java/com/umc/withme/exception/member/NicknameDuplicateException.java
@@ -1,0 +1,6 @@
+package com.umc.withme.exception.member;
+
+import com.umc.withme.exception.common.ConflictException;
+
+public class NicknameDuplicateException extends ConflictException {
+}

--- a/src/main/java/com/umc/withme/service/MemberService.java
+++ b/src/main/java/com/umc/withme/service/MemberService.java
@@ -5,6 +5,7 @@ import com.umc.withme.domain.Member;
 import com.umc.withme.dto.member.MemberDto;
 import com.umc.withme.exception.address.AddressNotFoundException;
 import com.umc.withme.exception.member.EmailNotFoundException;
+import com.umc.withme.exception.member.NicknameDuplicateException;
 import com.umc.withme.exception.member.NicknameNotFoundException;
 import com.umc.withme.repository.AddressRepository;
 import com.umc.withme.repository.MemberRepository;
@@ -85,7 +86,7 @@ public class MemberService {
     }
 
     /**
-     * memberId에 해당하는 회원 entity의 폰 번호를 phoneNumber로 설정한다.
+     * email로 조회한 회원 entity의 폰 번호를 phoneNumber로 설정한다.
      *
      * @param email 폰 번호를 설정할 회원의 email
      * @param phoneNumber   설정할 폰 번호
@@ -94,6 +95,22 @@ public class MemberService {
     public void updateMemberPhoneNumber(String email, String phoneNumber) {
         Member member = getMemberByEmail(email);
         member.setPhoneNumber(phoneNumber);
+    }
+
+    /**
+     * email로 조회한 회원의 닉네임을 설정한다
+     *
+     * @param email 닉네임을 설정할 회원의 email
+     * @param nickname  변경하려는 nickname
+     */
+    @Transactional
+    public void updateMemberNickname(String email, String nickname) {
+        if (checkNicknameDuplication(nickname)) {
+            throw new NicknameDuplicateException();
+        }
+
+        Member member = getMemberByEmail(email);
+        member.setNickname(nickname);
     }
 
     /**


### PR DESCRIPTION
## 관련 이슈
- Close #65 

## 작업 사항
- 회원 폰 번호 및 주소를 설정하는 API의 명세 중 잘못된 내용 수정
- 회원 API의 base uri를 `/api`에서 `/api/members`로 변경
- 회원 닉네임 설정/재설정 API 구현
  - DB의 unique 제약조건에 의해 exception이 발생되도록 하는 것은 바람직하지 않다는 의견을 보게 되었다. 고민이 좀 되는 부분이지만, 안정적으로 닉네임 수정 전에 중복 여부를 확인하고 exception을 throw 하도록 로직을 구성했다. 참고 자료는 다음과 같다.
  - 닉네임이 중복되는 경우는 기존 resource와의 충돌이므로 409 conflict error를 발생시킨다.

## 참고 자료
- [[Stack Overflow] `@Column(unique = true)`의 fatal exception 발생에 대한 내용](https://stackoverflow.com/questions/47176654/handling-jpas-columnunique-true-exception)

## 체크리스트
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
