### PR TITLE
받은 리뷰 수 조회 및 신뢰 점수 계산 로직 변경

### DIFF
--- a/src/main/java/com/umc/withme/controller/MeetController.java
+++ b/src/main/java/com/umc/withme/controller/MeetController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
-@Tag(name = "MeetController", description = "모임 API Controller 입니다.")
+@Tag(name = "모임/모집 글", description = "모임과 모집 글 관련 API입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -33,13 +33,6 @@ public class MeetController {
     private final MeetService meetService;
     private final ReviewService reviewService;
 
-    /**
-     * 모임글 생성 API
-     *
-     * @param meetFormRequest 생성하려는 모임 모집글 데이터
-     * @param principle
-     * @return 생성된 모임글 id를 data 에 담아서 반환한다.
-     */
     @Operation(
             summary = "모임 모집글 생성",
             description = "<p>request body 에 입력된 정보를 바탕으로 모임 모집글을 1개 생성합니다.</p>",
@@ -60,13 +53,6 @@ public class MeetController {
         );
     }
 
-    /**
-     * 모임 단건 조회 API
-     * 모임 id로 모임을 1건 조회한다.
-     *
-     * @param meetId 조회하려는 모임의 id
-     * @return 조회한 모임의 정보를 담은 MeetInfoGetResponse를 data에 담아서 반환한다.
-     */
     @Operation(
             summary = "모임 모집글 1개 조회 API",
             description = "<p><code>meetId</code>에 해당하는 모임의 정보를 response body 에 넣어 전달합니다.</p>",
@@ -88,13 +74,6 @@ public class MeetController {
         );
     }
 
-    /**
-     * 모임 모집글 수정 API
-     *
-     * @param meetId          수정하려는 모집글의 id
-     * @param meetFormRequest 수정하려는 정보가 담긴 요청 DTO
-     * @return 수정된 모임 모집글의 정보를 담은 MeetInfoGetResponse를 data에 담아서 반환한다.
-     */
     @Operation(
             summary = "모임 모집글 수정 API",
             description = "<p><code>meetId</code>에 해당하는 모임을 <code>request body</code>에 담긴 정보로 수정하고" +
@@ -120,13 +99,6 @@ public class MeetController {
         );
     }
 
-    /**
-     * 모임글 단건 삭제 API
-     * 모임의 id를 입력받아 해당하는 모임이 있으면 삭제한다.
-     *
-     * @param meetId 삭제하려는 모임의 id
-     * @return 삭제한 모임의 id를 데이터에 담아서 반환한다.
-     */
     @Operation(
             summary = "모임 모집글 1개 삭제 API",
             description = "<p><code>meetId</code>에 해당하는 모임을 삭제하고 삭제한 <code>meetId</code>를 response body에 넣어 전달합니다.</p>",

--- a/src/main/java/com/umc/withme/controller/MeetController.java
+++ b/src/main/java/com/umc/withme/controller/MeetController.java
@@ -5,10 +5,9 @@ import com.umc.withme.dto.common.DataResponse;
 import com.umc.withme.dto.meet.MeetCreateResponse;
 import com.umc.withme.dto.meet.MeetDto;
 import com.umc.withme.dto.meet.MeetFormRequest;
-import com.umc.withme.dto.meet.MeetInfoGetResponse;
+import com.umc.withme.dto.meet.MeetInfoResponse;
 import com.umc.withme.security.WithMeAppPrinciple;
 import com.umc.withme.service.MeetService;
-import com.umc.withme.service.ReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -31,7 +30,6 @@ import javax.validation.Valid;
 public class MeetController {
 
     private final MeetService meetService;
-    private final ReviewService reviewService;
 
     @Operation(
             summary = "모임 모집글 생성",
@@ -63,10 +61,10 @@ public class MeetController {
             @ApiResponse(responseCode = "404", description = "2400: <code>meetId</code>에 해당하는 모임이 없는 경우", content = @Content)
     })
     @GetMapping("/meets/{meetId}")
-    public ResponseEntity<DataResponse<MeetInfoGetResponse>> getMeet(@PathVariable Long meetId) {
+    public ResponseEntity<DataResponse<MeetInfoResponse>> getMeet(@PathVariable Long meetId) {
         MeetDto meetDto = meetService.findById(meetId);
 
-        MeetInfoGetResponse response = MeetInfoGetResponse.of(meetDto, reviewService.getReceivedReviewsCount(meetDto.getLeader().getId()));
+        MeetInfoResponse response = MeetInfoResponse.from(meetDto);
 
         return new ResponseEntity<>(
                 new DataResponse<>(response),
@@ -85,13 +83,13 @@ public class MeetController {
             @ApiResponse(responseCode = "404", description = "2400: <code>meetId</code>에 해당하는 모임이 없는 경우", content = @Content)
     })
     @PutMapping("/meets/{meetId}")
-    public ResponseEntity<DataResponse<MeetInfoGetResponse>> updateMeet(
+    public ResponseEntity<DataResponse<MeetInfoResponse>> updateMeet(
             @PathVariable Long meetId,
             @Valid @RequestBody MeetFormRequest meetFormRequest,
             @Parameter(hidden = true) @AuthenticationPrincipal WithMeAppPrinciple principle) {
         MeetDto meetDto = meetService.updateById(meetId, principle.getMemberId(), meetFormRequest.toDto());
 
-        MeetInfoGetResponse response = MeetInfoGetResponse.of(meetDto, reviewService.getReceivedReviewsCount(meetDto.getLeader().getId()));
+        MeetInfoResponse response = MeetInfoResponse.from(meetDto);
 
         return new ResponseEntity<>(
                 new DataResponse<>(response),

--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -5,7 +5,6 @@ import com.umc.withme.dto.common.DataResponse;
 import com.umc.withme.dto.member.*;
 import com.umc.withme.security.WithMeAppPrinciple;
 import com.umc.withme.service.MemberService;
-import com.umc.withme.service.ReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -29,7 +28,6 @@ import javax.validation.constraints.NotBlank;
 public class MemberController {
 
     private final MemberService memberService;
-    private final ReviewService reviewService;
 
     @Operation(
             summary = "닉네임 중복 조회",
@@ -58,7 +56,7 @@ public class MemberController {
     @GetMapping
     public ResponseEntity<DataResponse<MemberAllInfoResponse>> getMemberInfo(@RequestParam @NotBlank String nickname) {
         MemberDto memberDto = memberService.findMemberByNickname(nickname);
-        MemberAllInfoResponse response = MemberAllInfoResponse.of(memberDto, reviewService.getReceivedReviewsCount(memberDto.getId()));
+        MemberAllInfoResponse response = MemberAllInfoResponse.from(memberDto);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new DataResponse<>(response));

--- a/src/main/java/com/umc/withme/domain/Member.java
+++ b/src/main/java/com/umc/withme/domain/Member.java
@@ -4,6 +4,7 @@ import com.umc.withme.domain.common.BaseTimeEntity;
 import com.umc.withme.domain.constant.Gender;
 import com.umc.withme.domain.constant.RoleType;
 import lombok.*;
+import org.hibernate.annotations.Formula;
 
 import javax.persistence.*;
 import java.util.Objects;
@@ -53,6 +54,11 @@ public class Member extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private RoleType roleType;
+
+    @Formula("(select count(r.review_id) " +
+            "from review r " +
+            "where r.receiver_id=member_id)")
+    private int numOfReceivedReviews;
 
     // Builder & Constructor
     @Builder

--- a/src/main/java/com/umc/withme/domain/Member.java
+++ b/src/main/java/com/umc/withme/domain/Member.java
@@ -58,7 +58,7 @@ public class Member extends BaseTimeEntity {
     @Formula("(select count(r.review_id) " +
             "from review r " +
             "where r.receiver_id=member_id)")
-    private int numOfReceivedReviews;
+    private Integer numOfReceivedReviews;
 
     // Builder & Constructor
     @Builder

--- a/src/main/java/com/umc/withme/domain/TotalPoint.java
+++ b/src/main/java/com/umc/withme/domain/TotalPoint.java
@@ -1,5 +1,6 @@
 package com.umc.withme.domain;
 
+import com.umc.withme.dto.member.MemberDto;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -27,5 +28,23 @@ public class TotalPoint {
         this.attendanceTotalPoint = 0;
         this.passionTotalPoint = 0;
         this.contactTotalPoint = 0;
+    }
+
+    /**
+     * 출석, 열정, 연락 점수를 바탕으로 신뢰 점수를 계산한다.
+     *
+     * @param numOfReceivedReviews 받은 리뷰 수
+     * @return 계산된 신뢰 점수
+     */
+    public double calculateTrustPoint(int numOfReceivedReviews) {
+        if (numOfReceivedReviews == 0) {
+            return 0.0;
+        }
+
+        Double attendanceAverage = this.getAttendanceTotalPoint() / (double) numOfReceivedReviews;
+        Double passionAverage = this.getPassionTotalPoint() / (double) numOfReceivedReviews;
+        Double contactAverage = this.getContactTotalPoint() / (double) numOfReceivedReviews;
+
+        return (attendanceAverage + passionAverage + contactAverage) / 3.0;
     }
 }

--- a/src/main/java/com/umc/withme/dto/meet/MeetInfoResponse.java
+++ b/src/main/java/com/umc/withme/dto/meet/MeetInfoResponse.java
@@ -15,15 +15,16 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class MeetInfoGetResponse {
+public class MeetInfoResponse {
 
     @Schema(example = "2", description = "조회한 모임의 id")
     private Long meetId;
 
-    @Schema(example = "", description = "모임을 생성한 사용자 정보 (모임의 리더 정보)")
-    private MemberShortInfoResponse leader;  // 이 모임의 리더
+    @Schema(description = "모임을 생성한 사용자 정보 (모임의 리더 정보)")
+    private MemberShortInfoResponse leader;
 
-    private List<AddressDto> addresses;  // 이 모임에 설정된 동네 리스트
+    @Schema(description = "이 모임에 설정된 지역 리스트")
+    private List<AddressDto> addresses;
 
     @Schema(example = "STUDY", description = "모임의 카테고리")
     private MeetCategory meetCategory;
@@ -37,13 +38,10 @@ public class MeetInfoGetResponse {
     @Schema(example = "OOO 스터디원 모집합니다!", description = "모임 모집글의 제목")
     private String title;
 
-    @Schema(example = "https://open.kakao.com/o/s1RrvrQe",
-            description = "추가적으로 사용할 카톡 오픈채팅 링크 또는 모집 폼 링크")
+    @Schema(example = "https://open.kakao.com/o/s1RrvrQe", description = "추가적으로 사용할 카톡 오픈채팅 링크 또는 모집 폼 링크")
     private String link;
 
-    @Schema(
-            example = "함께 OOO 공부 하고 자료도 나누면서 함께 성장해봐요!",
-            description = "모임 모집글의 내용")
+    @Schema(example = "함께 OOO 공부 하고 자료도 나누면서 함께 성장해봐요!", description = "모임 모집글의 내용")
     private String content;
 
     @Schema(example = "3", description = "모임의 최소 인원")
@@ -58,11 +56,11 @@ public class MeetInfoGetResponse {
     @Schema(example = "2023-02-15", description = "모임 마감(종료) 날짜")
     private LocalDate endDate;
 
-    public static MeetInfoGetResponse of(MeetDto dto, Long receivedReviewsCount) {
+    public static MeetInfoResponse from(MeetDto dto) {
 
-        return new MeetInfoGetResponse(
+        return new MeetInfoResponse(
                 dto.getMeetId(),
-                MemberShortInfoResponse.of(dto.getLeader(), receivedReviewsCount),
+                MemberShortInfoResponse.from(dto.getLeader()),
                 dto.getAddresses(),
                 dto.getMeetCategory(),
                 dto.getRecruitStatus(),

--- a/src/main/java/com/umc/withme/dto/member/MemberAllInfoResponse.java
+++ b/src/main/java/com/umc/withme/dto/member/MemberAllInfoResponse.java
@@ -37,10 +37,10 @@ public class MemberAllInfoResponse {
     private TotalPoint totalPoint;
 
     @Schema(description = "받은 리뷰 개수")
-    private Long receivedReviewsCount;
+    private Integer numOfReceivedReviews;
 
 
-    public static MemberAllInfoResponse of(MemberDto dto, Long receivedReviewsCount) {
+    public static MemberAllInfoResponse from(MemberDto dto) {
         return new MemberAllInfoResponse(
                 dto.getNickname(),
                 dto.getPhoneNumber(),
@@ -49,7 +49,7 @@ public class MemberAllInfoResponse {
                 dto.getEmail(),
                 dto.getAddress(),
                 dto.getTotalPoint(),
-                receivedReviewsCount
+                dto.getNumOfReceivedReviews()
         );
     }
 }

--- a/src/main/java/com/umc/withme/dto/member/MemberDto.java
+++ b/src/main/java/com/umc/withme/dto/member/MemberDto.java
@@ -22,21 +22,19 @@ public class MemberDto {
     private Integer ageRange;
     private Gender gender;
     private TotalPoint totalPoint;
+    private Integer numOfReceivedReviews;
     private RoleType roleType;
 
     public static MemberDto of(String email, String password, Integer ageRange, Gender gender) {
-        return MemberDto.of(null, null, email, password, null, null, ageRange, gender, null, null);
+        return MemberDto.of(null, null, email, password, null, null, ageRange, gender, null, null, null);
     }
 
-    public static MemberDto of(Long id, AddressDto address, String email, String password, String phoneNumber, String nickname, Integer ageRange, Gender gender, TotalPoint totalPoint, RoleType roleType) {
-        return new MemberDto(id, address, email, password, phoneNumber, nickname, ageRange, gender, totalPoint, roleType);
+    public static MemberDto of(Long id, AddressDto address, String email, String password, String phoneNumber, String nickname, Integer ageRange, Gender gender, TotalPoint totalPoint, Integer numOfReceivedReviews, RoleType roleType) {
+        return new MemberDto(id, address, email, password, phoneNumber, nickname, ageRange, gender, totalPoint, numOfReceivedReviews, roleType);
     }
 
     public static MemberDto from(Member member) {
-        AddressDto addressDto = null;
-        if (member.getAddress() != null) {
-            addressDto = AddressDto.from(member.getAddress());
-        }
+        AddressDto addressDto = member.getAddress() != null ? AddressDto.from(member.getAddress()) : null;
 
         return MemberDto.of(
                 member.getId(),
@@ -48,6 +46,7 @@ public class MemberDto {
                 member.getAgeRange(),
                 member.getGender(),
                 member.getTotalPoint(),
+                member.getNumOfReceivedReviews(),
                 member.getRoleType()
         );
     }

--- a/src/main/java/com/umc/withme/dto/member/MemberShortInfoResponse.java
+++ b/src/main/java/com/umc/withme/dto/member/MemberShortInfoResponse.java
@@ -20,14 +20,14 @@ public class MemberShortInfoResponse {
     @Schema(description = "회원 주소 中 시군구 정보")
     private String sggAddress;
 
-    public static MemberShortInfoResponse of(MemberDto memberDto, Long receivedReviewsCount){
-        TotalPoint totalPoint = memberDto.getTotalPoint();
-        Double attendanceAverage = totalPoint.getAttendanceTotalPoint()/(double)receivedReviewsCount;
-        Double passionAverage = totalPoint.getPassionTotalPoint()/ (double)receivedReviewsCount;
-        Double contactAverage = totalPoint.getContactTotalPoint()/(double)receivedReviewsCount;
-        Double trustPoint = (attendanceAverage + passionAverage + contactAverage)/3;
+    public static MemberShortInfoResponse from(MemberDto memberDto) {
+        double trustPoint = memberDto.getTotalPoint().calculateTrustPoint(memberDto.getNumOfReceivedReviews());
 
-        return new MemberShortInfoResponse(memberDto.getId(), memberDto.getNickname(), trustPoint, memberDto.getAddress().getSgg());
+        return new MemberShortInfoResponse(
+                memberDto.getId(),
+                memberDto.getNickname(),
+                trustPoint,
+                memberDto.getAddress().getSgg()
+        );
     }
-
 }

--- a/src/main/java/com/umc/withme/service/ReviewService.java
+++ b/src/main/java/com/umc/withme/service/ReviewService.java
@@ -1,10 +1,16 @@
 package com.umc.withme.service;
 
-import com.umc.withme.domain.*;
+import com.umc.withme.domain.Meet;
+import com.umc.withme.domain.Member;
+import com.umc.withme.domain.Point;
+import com.umc.withme.domain.Review;
 import com.umc.withme.dto.review.ReviewCreateRequest;
 import com.umc.withme.exception.meet.MeetIdNotFoundException;
 import com.umc.withme.exception.member.MemberIdNotFoundException;
-import com.umc.withme.repository.*;
+import com.umc.withme.repository.MeetRepository;
+import com.umc.withme.repository.MemberRepository;
+import com.umc.withme.repository.PointRepository;
+import com.umc.withme.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,17 +51,6 @@ public class ReviewService {
                 .content(requestDto.getContent())
                 .build();
 
-        Review saveReview = reviewRepository.save(review);
-
-        return saveReview.getId();
-    }
-
-    /**
-     * 받은 리뷰 개수 조회
-     * @param memberId 본인(받은 사람) 회원 id(pk)
-     * @return 받은 리뷰 개수
-     */
-    public Long getReceivedReviewsCount(Long memberId){
-        return reviewRepository.countByReceiver_Id(memberId);
+        return reviewRepository.save(review).getId();
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #59 

## 작업 사항
기존 코드에서는 dto 각 메서드의 역할과 parameter가 조금 어색한 부분이 있었다. 
이에 다음과 같은 내용들을 적용하여 수정하였음.
- `Member`에 "받은 리뷰 수" 필드 추가 및 `@Formula`를 활용하여 자체적으로 받은 리뷰 수를 조회할 수 있도록 하였음.
  - 이에 따라 더 이상 필요 없어진 `ReviewService`의 "받은 리뷰 수 조회" method를 삭제.
  - 이렇게 함으로써 `MeetController`와 `MemberController`가 더 이상 `ReviewService`에 의존하지 않아도 된다.
  - 다만, `Member` entity를 조회할 때, 필요한 상황이 아니더라도 "받은 리뷰 수"를 항상 조회한다는 side effect가 있음. 하지만 이는 query가 추가로 생성되는 것이 아닌, 회원을 조회할 때 sub query로 함께 조회되는 것이기 때문에 "받은 리뷰 수"의 사용 빈도를 고려했을 때 이점이 더 크다고 판단하였음.

- 신뢰 점수 계산 로직을 `TotalPoint` class에 위임.
  - 신뢰 점수 계산은 결국 `TotalPoint`와 관련된 로직이라고 판단하였고, 때문에 `TotalPoint` 클래스에 신뢰 점수 계산 로직을 위임하였음.
  - 기존 코드에는 "받은 리뷰 수"가 0일 때 나누는 것에 대한 예외처리가 안되었던 것 같아서, "받은 리뷰 수"가 0인 경우, 계산된 신뢰 점수로 `0`을 return하도록 하였음.

## 참고 자료
- None

## 체크리스트
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
