### PR TITLE
모임 해제 기능 구현

### DIFF
--- a/src/main/java/com/umc/withme/controller/MeetController.java
+++ b/src/main/java/com/umc/withme/controller/MeetController.java
@@ -166,4 +166,24 @@ public class MeetController {
                 HttpStatus.OK
         );
     }
+
+    @Operation(
+            summary = "모임 해제 API",
+            description = "<p><code>meetId</code>에 해당하는 모임을 해제 상태로 변경합니다.</p>",
+            security = @SecurityRequirement(name = "access-token")
+    )
+    @PatchMapping("/meets/{meetId}")
+    public ResponseEntity<DataResponse<MeetInfoGetResponse>> setMeetComplete(
+            @PathVariable Long meetId,
+            @Parameter(hidden = true) @AuthenticationPrincipal WithMeAppPrinciple principle
+    ) {
+        MeetDto meetDto = meetService.setMeetComplete(meetId, principle.getMemberId());
+
+        MeetInfoGetResponse response = MeetInfoGetResponse.from(meetDto);
+
+        return new ResponseEntity<>(
+                new DataResponse<>(response),
+                HttpStatus.OK
+        );
+    }
 }

--- a/src/main/java/com/umc/withme/domain/Meet.java
+++ b/src/main/java/com/umc/withme/domain/Meet.java
@@ -5,10 +5,7 @@ import com.umc.withme.domain.constant.MeetCategory;
 import com.umc.withme.domain.constant.MeetStatus;
 import com.umc.withme.domain.constant.RecruitStatus;
 import com.umc.withme.dto.meet.MeetDto;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -32,6 +29,7 @@ public class Meet extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private RecruitStatus recruitStatus;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     private MeetStatus meetStatus;
 

--- a/src/main/java/com/umc/withme/exception/ExceptionType.java
+++ b/src/main/java/com/umc/withme/exception/ExceptionType.java
@@ -3,6 +3,7 @@ package com.umc.withme.exception;
 import com.umc.withme.exception.address.AddressNotFoundException;
 import com.umc.withme.exception.auth.KakaoOAuthUnauthorizedException;
 import com.umc.withme.exception.common.CustomException;
+import com.umc.withme.exception.meet.MeetCompleteForbiddenException;
 import com.umc.withme.exception.meet.MeetDeleteForbiddenException;
 import com.umc.withme.exception.meet.MeetIdNotFoundException;
 import com.umc.withme.exception.meet.MeetUpdateForbiddenException;
@@ -54,6 +55,7 @@ public enum ExceptionType {
     MEET_ID_NOT_FOUND_EXCEPTION(2400, "해당 아이디(PK)를 가지는 모임이 없습니다.", MeetIdNotFoundException.class),
     MEET_DELETE_FORBIDDEN_EXCEPTION(2401, "해당 모임을 삭제할 권한이 없습니다.", MeetDeleteForbiddenException.class),
     MEET_UPDATE_FORBIDDEN_EXCEPTION(2402, "해당 모임을 수정할 권한이 없습니다.", MeetUpdateForbiddenException.class),
+    MEET_COMPLETE_FORBIDDEN_EXCEPTION(2403, "해당 모임을 해제할 권한이 없습니다.", MeetCompleteForbiddenException.class),
 
     // Address
     ADDRESS_NOT_FOUND_EXCEPTION(3400, "일치하는 주소를 찾을 수 없습니다.", AddressNotFoundException.class);

--- a/src/main/java/com/umc/withme/exception/meet/MeetCompleteForbiddenException.java
+++ b/src/main/java/com/umc/withme/exception/meet/MeetCompleteForbiddenException.java
@@ -1,0 +1,17 @@
+package com.umc.withme.exception.meet;
+
+import com.umc.withme.exception.common.ForbiddenException;
+
+public class MeetCompleteForbiddenException extends ForbiddenException {
+
+    /**
+     * 모임의 리더가 아닌 사용자가 모임을 해제하려고 했을 때 발생하는 예외이다.
+     * 모임의 id와 사용자 id를 입력받아 에러 로그와 함께 출력한다.
+     *
+     * @param meetId 해제하려는 모임 id
+     * @param memberId 해제하려는 사용자 id
+     */
+    public MeetCompleteForbiddenException(Long meetId, Long memberId){
+        super("meetId=" + meetId + " memberId=" + memberId);
+    }
+}

--- a/src/main/java/com/umc/withme/service/MeetService.java
+++ b/src/main/java/com/umc/withme/service/MeetService.java
@@ -231,14 +231,11 @@ public class MeetService {
         Meet meet = meetRepository.findById(meetId)
                 .orElseThrow(() -> new MeetIdNotFoundException(meetId));
 
+        // 사용자가 모임의 리더가 아닐 경우 예외 발생
+        if (memberId != meet.getCreatedBy()) throw new MeetCompleteForbiddenException(meetId, memberId);
+
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberIdNotFoundException(memberId));
-
-        Member meetLeader = memberRepository.findById(meet.getCreatedBy())
-                .orElseThrow(() -> new MemberIdNotFoundException(meet.getCreatedBy()));
-
-        // 사용자가 모임의 리더가 아닐 경우 예외 발생
-        if (member != meetLeader) throw new MeetCompleteForbiddenException(meetId, memberId);
 
         // 모임의 상태를 완료 상태로 변경
         meet.setMeetStatus(MeetStatus.COMPLETE);

--- a/src/main/java/com/umc/withme/service/MeetService.java
+++ b/src/main/java/com/umc/withme/service/MeetService.java
@@ -2,11 +2,13 @@ package com.umc.withme.service;
 
 import com.umc.withme.domain.*;
 import com.umc.withme.domain.constant.MeetCategory;
+import com.umc.withme.domain.constant.MeetStatus;
 import com.umc.withme.dto.address.AddressDto;
 import com.umc.withme.dto.meet.MeetDto;
 import com.umc.withme.dto.meet.MeetRecordSearch;
 import com.umc.withme.dto.meet.MeetSearch;
 import com.umc.withme.exception.address.AddressNotFoundException;
+import com.umc.withme.exception.meet.MeetCompleteForbiddenException;
 import com.umc.withme.exception.meet.MeetDeleteForbiddenException;
 import com.umc.withme.exception.meet.MeetIdNotFoundException;
 import com.umc.withme.exception.meet.MeetUpdateForbiddenException;
@@ -214,5 +216,39 @@ public class MeetService {
         }
 
         return meetDtos;
+    }
+
+    /**
+     * 사용자가 모임의 리더인 경우, 모임의 상태가 완료 상태로 변경되고 변경된 모임 DTO를 반환한다.
+     * 사용자가 모임의 리더가 아닌 경우, 예외가 발생한다.
+     *
+     * @param meetId   해제하려는 모임 id
+     * @param memberId 현재 로그인한 사용자 id
+     * @return 모임의 상태가 완료로 변경된 모임 DTO
+     */
+    @Transactional
+    public MeetDto setMeetComplete(Long meetId, Long memberId) {
+        Meet meet = meetRepository.findById(meetId)
+                .orElseThrow(() -> new MeetIdNotFoundException(meetId));
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberIdNotFoundException(memberId));
+
+        Member meetLeader = memberRepository.findById(meet.getCreatedBy())
+                .orElseThrow(() -> new MemberIdNotFoundException(meet.getCreatedBy()));
+
+        // 사용자가 모임의 리더가 아닐 경우 예외 발생
+        if (member != meetLeader) throw new MeetCompleteForbiddenException(meetId, memberId);
+
+        // 모임의 상태를 완료 상태로 변경
+        meet.setMeetStatus(MeetStatus.COMPLETE);
+
+        // meet에 등록된 주소 리스트 조회
+        List<Address> addresses = meetAddressRepository.findAllByMeet_Id(meetId)
+                .stream()
+                .map(MeetAddress::getAddress)
+                .collect(Collectors.toUnmodifiableList());
+
+        return MeetDto.from(meet, addresses, member);
     }
 }


### PR DESCRIPTION
## 관련 이슈
- close #91 

## 작업 사항
- 모임의 id를 입력받아 사용자가 모임의 리더인지 체크하고, 모임의 meetStatus를 COMPLETE로 변경하고, 해당 모임 DTO를 반환하도록 구현하였습니다.
- 현재 meetStatus나 recruitStatus는 따로 체크하는 로직이 필요 없을 것 같아서 안했는데, 필요하면 지 말씀해주시면 해당 방향으로 수정하도록 하겠습니다!

## 참고 자료
- 참고자료 (링크 등)

## 체크리스트
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
