### PR TITLE
회원 프로필 사진 등록 및 변경 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     // Spring Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // Spring Cloud AWS
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
 

--- a/src/main/java/com/umc/withme/controller/MemberController.java
+++ b/src/main/java/com/umc/withme/controller/MemberController.java
@@ -13,10 +13,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -115,6 +117,27 @@ public class MemberController {
 
         return ResponseEntity
                 .status(HttpStatus.OK)
+                .body(new BaseResponse(true));
+    }
+
+    @Operation(
+            summary = "회원 프로필 이미지 설정",
+            description = "<p>로그인 중인 회원의 프로필 이미지를 교체합니다.</p>",
+            security = @SecurityRequirement(name = "access-token")
+    )
+    @PatchMapping(
+            value = "/profile-image",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<BaseResponse> updateMemberProfileImage(
+            @Parameter(hidden = true) @AuthenticationPrincipal WithMeAppPrinciple principle,
+            @Parameter(description = "교체할 이미지 파일") @RequestPart MultipartFile profileImageFile
+    ) {
+        memberService.updateMemberProfileImage(principle.getUsername(), profileImageFile);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
                 .body(new BaseResponse(true));
     }
 }

--- a/src/main/java/com/umc/withme/domain/ImageFile.java
+++ b/src/main/java/com/umc/withme/domain/ImageFile.java
@@ -1,0 +1,50 @@
+package com.umc.withme.domain;
+
+import com.umc.withme.domain.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class ImageFile extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_file_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String storedFileName;
+
+    @Column(nullable = false)
+    private String url;
+
+    @Builder
+    private ImageFile(String fileName, String storedFileName, String url) {
+        this.fileName = fileName;
+        this.storedFileName = storedFileName;
+        this.url = url;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ImageFile)) return false;
+        ImageFile that = (ImageFile) o;
+        return this.getId() != null && this.getId().equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getId());
+    }
+}

--- a/src/main/java/com/umc/withme/domain/Member.java
+++ b/src/main/java/com/umc/withme/domain/Member.java
@@ -19,6 +19,11 @@ public class Member extends BaseTimeEntity {
     private Long id;
 
     @Setter
+    @JoinColumn(name = "profile_image_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    private ImageFile profileImage;
+
+    @Setter
     @JoinColumn(name = "address_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Address address;
@@ -56,7 +61,8 @@ public class Member extends BaseTimeEntity {
 
     // Builder & Constructor
     @Builder
-    private Member(String email, String password, Integer ageRange, Gender gender) {
+    private Member(ImageFile profileImage, String email, String password, Integer ageRange, Gender gender) {
+        this.profileImage = profileImage;
         this.email = email;
         this.password = password;
         this.nickname = email;

--- a/src/main/java/com/umc/withme/dto/ImageFileDto.java
+++ b/src/main/java/com/umc/withme/dto/ImageFileDto.java
@@ -1,0 +1,29 @@
+package com.umc.withme.dto;
+
+import com.umc.withme.domain.ImageFile;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ImageFileDto {
+
+    private Long id;
+    private String fileName;
+    private String storedFileName;
+    private String url;
+
+    public static ImageFileDto of(Long id, String fileName, String storedFileName, String url) {
+        return new ImageFileDto(id, fileName, storedFileName, url);
+    }
+
+    public static ImageFileDto from(ImageFile imageFile) {
+        return of(
+                imageFile.getId(),
+                imageFile.getFileName(),
+                imageFile.getStoredFileName(),
+                imageFile.getUrl()
+        );
+    }
+}

--- a/src/main/java/com/umc/withme/dto/member/MemberDto.java
+++ b/src/main/java/com/umc/withme/dto/member/MemberDto.java
@@ -1,9 +1,11 @@
 package com.umc.withme.dto.member;
 
+import com.umc.withme.domain.ImageFile;
 import com.umc.withme.domain.Member;
 import com.umc.withme.domain.TotalPoint;
 import com.umc.withme.domain.constant.Gender;
 import com.umc.withme.domain.constant.RoleType;
+import com.umc.withme.dto.ImageFileDto;
 import com.umc.withme.dto.address.AddressDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,6 +16,7 @@ import lombok.Getter;
 public class MemberDto {
 
     private Long id;
+    private ImageFileDto profileImage;
     private AddressDto address;
     private String email;
     private String password;
@@ -25,11 +28,11 @@ public class MemberDto {
     private RoleType roleType;
 
     public static MemberDto of(String email, String password, Integer ageRange, Gender gender) {
-        return MemberDto.of(null, null, email, password, null, null, ageRange, gender, null, null);
+        return MemberDto.of(null, null, null, email, password, null, null, ageRange, gender, null, null);
     }
 
-    public static MemberDto of(Long id, AddressDto address, String email, String password, String phoneNumber, String nickname, Integer ageRange, Gender gender, TotalPoint totalPoint, RoleType roleType) {
-        return new MemberDto(id, address, email, password, phoneNumber, nickname, ageRange, gender, totalPoint, roleType);
+    public static MemberDto of(Long id, ImageFileDto profileImage, AddressDto address, String email, String password, String phoneNumber, String nickname, Integer ageRange, Gender gender, TotalPoint totalPoint, RoleType roleType) {
+        return new MemberDto(id, profileImage, address, email, password, phoneNumber, nickname, ageRange, gender, totalPoint, roleType);
     }
 
     public static MemberDto from(Member member) {
@@ -40,6 +43,7 @@ public class MemberDto {
 
         return MemberDto.of(
                 member.getId(),
+                ImageFileDto.from(member.getProfileImage()),
                 addressDto,
                 member.getEmail(),
                 member.getPassword(),
@@ -52,8 +56,9 @@ public class MemberDto {
         );
     }
 
-    public Member toEntity() {
+    public Member toEntity(ImageFile profileImage) {
         return Member.builder()
+                .profileImage(profileImage)
                 .email(this.email)
                 .password(this.password)
                 .ageRange(this.ageRange)

--- a/src/main/java/com/umc/withme/dto/member/MemberInfoGetResponse.java
+++ b/src/main/java/com/umc/withme/dto/member/MemberInfoGetResponse.java
@@ -14,6 +14,9 @@ public class MemberInfoGetResponse {
     @Schema(example = "park", description = "회원의 닉네임")
     private String nickname;
 
+    @Schema(example = "https://withme-s3-bucket.s3.ap-northeast-2.amazonaws.com/member/default-profile-image.jpeg", description = "프로필 이미지 URL")
+    private String profileImage;
+
     @Schema(example = "010-1234-5678", description = "회원의 핸드폰 번호")
     private String phoneNumber;
 
@@ -29,6 +32,7 @@ public class MemberInfoGetResponse {
     public static MemberInfoGetResponse from(MemberDto dto) {
         return new MemberInfoGetResponse(
                 dto.getNickname(),
+                dto.getProfileImage().getUrl(),
                 dto.getPhoneNumber(),
                 dto.getAgeRange(),
                 dto.getGender(),

--- a/src/main/java/com/umc/withme/exception/ExceptionType.java
+++ b/src/main/java/com/umc/withme/exception/ExceptionType.java
@@ -3,12 +3,13 @@ package com.umc.withme.exception;
 import com.umc.withme.exception.address.AddressNotFoundException;
 import com.umc.withme.exception.auth.KakaoOAuthUnauthorizedException;
 import com.umc.withme.exception.common.CustomException;
+import com.umc.withme.exception.file.MultipartFileNotReadableException;
 import com.umc.withme.exception.meet.MeetDeleteForbiddenException;
 import com.umc.withme.exception.meet.MeetIdNotFoundException;
 import com.umc.withme.exception.meet.MeetUpdateForbiddenException;
 import com.umc.withme.exception.member.EmailNotFoundException;
-import com.umc.withme.exception.member.NicknameDuplicateException;
 import com.umc.withme.exception.member.MemberIdNotFoundException;
+import com.umc.withme.exception.member.NicknameDuplicateException;
 import com.umc.withme.exception.member.NicknameNotFoundException;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -56,7 +57,10 @@ public enum ExceptionType {
     MEET_UPDATE_FORBIDDEN_EXCEPTION(2402, "해당 모임을 수정할 권한이 없습니다.", MeetUpdateForbiddenException.class),
 
     // Address
-    ADDRESS_NOT_FOUND_EXCEPTION(3400, "일치하는 주소를 찾을 수 없습니다.", AddressNotFoundException.class);
+    ADDRESS_NOT_FOUND_EXCEPTION(3400, "일치하는 주소를 찾을 수 없습니다.", AddressNotFoundException.class),
+
+    // File
+    MULTIPART_FILE_NOT_READABLE_EXCEPTION(4400, "파일을 읽을 수 없습니다.", MultipartFileNotReadableException.class);
 
     private final int errorCode;
     private final String errorMessage;

--- a/src/main/java/com/umc/withme/exception/file/MultipartFileNotReadableException.java
+++ b/src/main/java/com/umc/withme/exception/file/MultipartFileNotReadableException.java
@@ -1,0 +1,6 @@
+package com.umc.withme.exception.file;
+
+import com.umc.withme.exception.common.BadRequestException;
+
+public class MultipartFileNotReadableException extends BadRequestException {
+}

--- a/src/main/java/com/umc/withme/repository/ImageFileRepository.java
+++ b/src/main/java/com/umc/withme/repository/ImageFileRepository.java
@@ -1,0 +1,18 @@
+package com.umc.withme.repository;
+
+import com.umc.withme.domain.ImageFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
+
+    @Query("select count(imgfile.id) > 0 from ImageFile imgfile " +
+            "where imgfile.fileName = 'default-profile-image' " +
+            "and imgfile.storedFileName = 'default-profile-image'")
+    boolean existsDefaultMemberProfileImage();
+
+    @Query("select imgfile from ImageFile imgfile " +
+            "where imgfile.fileName = 'default-profile-image' " +
+            "and imgfile.storedFileName = 'default-profile-image'")
+    ImageFile getDefaultMemberProfileImage();
+}

--- a/src/main/java/com/umc/withme/repository/MemberRepository.java
+++ b/src/main/java/com/umc/withme/repository/MemberRepository.java
@@ -24,8 +24,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
      * @param nickname
      * @return Member 객체
      */
-    @EntityGraph(attributePaths = {"address"})
+    @EntityGraph(attributePaths = {"profileImage", "address"})
     Optional<Member> findByNickname(String nickname);
 
+    @EntityGraph(attributePaths = {"profileImage", "address"})
     Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/umc/withme/service/S3FileService.java
+++ b/src/main/java/com/umc/withme/service/S3FileService.java
@@ -1,0 +1,117 @@
+package com.umc.withme.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.umc.withme.domain.ImageFile;
+import com.umc.withme.exception.file.MultipartFileNotReadableException;
+import com.umc.withme.repository.ImageFileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class S3FileService {
+
+    private final AmazonS3Client s3Client;
+    private final ImageFileRepository imageFileRepository;
+
+    private static final String DIR_PATH = "member/";
+    private static final String DEFAULT_PROFILE_IMAGE_NAME = "default-profile-image.jpeg";
+
+    @Value("${cloud.aws.s3.bucket-name}")
+    private String bucketName;
+
+    /**
+     * S3 bucket에서 회원의 기본 프로필 이미지를 조회한 후 DB에 저장한다.
+     */
+    @Transactional
+    public ImageFile saveMemberDefaultImage() {
+        String defaultImageUrl = s3Client.getResourceUrl(bucketName, DIR_PATH + DEFAULT_PROFILE_IMAGE_NAME);
+        return imageFileRepository.saveAndFlush(
+                ImageFile.builder()
+                        .fileName(DEFAULT_PROFILE_IMAGE_NAME)
+                        .storedFileName(DEFAULT_PROFILE_IMAGE_NAME)
+                        .url(defaultImageUrl)
+                        .build()
+        );
+    }
+
+    /**
+     * 전달받은 파일을 S3 bucket에 저장한 후 이를 바탕으로 ImageFile entity를 생성하여 DB에 저장한 후 반환한다.
+     *
+     * @param multipartFile S3 bucket과 DB에 저장할 파일
+     * @return 저장된 ImageFile entity
+     * @throws  MultipartFileNotReadableException 전달받은 파일을 읽는 데 문제가 발생한 경우. (multipartFile.getInputStream()에서 IOException이 던져진 경우)
+     */
+    @Transactional
+    public ImageFile saveFile(MultipartFile multipartFile) {
+        String originalFilename = multipartFile.getOriginalFilename();
+        if (originalFilename == null) {
+            originalFilename = "";
+        }
+        String storeFileName = createStoreFileName(originalFilename);
+        ObjectMetadata objectMetadata = createMetadataWithContentInfo(multipartFile);
+
+        try {
+            InputStream inputStream = multipartFile.getInputStream();
+            s3Client.putObject(
+                    new PutObjectRequest(
+                            bucketName,
+                            storeFileName,
+                            inputStream,
+                            objectMetadata
+                    ).withCannedAcl(CannedAccessControlList.PublicRead)
+            );
+            String storedFileUrl = s3Client.getResourceUrl(bucketName, storeFileName);
+
+            return imageFileRepository.save(
+                    ImageFile.builder()
+                            .fileName(originalFilename)
+                            .storedFileName(storeFileName)
+                            .url(storedFileUrl)
+                            .build()
+            );
+        } catch (IOException e) {
+            log.error("FileUploadService.saveFile() ex={} fileName={}", e, multipartFile.getOriginalFilename());
+            throw new MultipartFileNotReadableException();
+        }
+    }
+
+    /**
+     * 전달받은 imageFile entity를 S3 bucket과 DB에서 삭제한다.
+     *
+     * @param imageFile 삭제할 imageFile entity
+     */
+    @Transactional
+    public void deleteFile(ImageFile imageFile) {
+        s3Client.deleteObject(bucketName, imageFile.getStoredFileName());
+        imageFileRepository.delete(imageFile);
+    }
+
+    private String createStoreFileName(String originalFilename) {
+        // Extract file extension
+        int pos = originalFilename.lastIndexOf(".");
+        String extension = originalFilename.substring(pos + 1);
+        String uuid = UUID.randomUUID().toString();
+        return DIR_PATH + uuid + "." + extension;
+    }
+
+    private ObjectMetadata createMetadataWithContentInfo(MultipartFile multipartFile) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+        objectMetadata.setContentLength(multipartFile.getSize());
+        return objectMetadata;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,18 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
 
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_S3_ACCESS_KEY}
+      secret-key: ${AWS_S3_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket-name: withme-s3-bucket
+    stack:
+      auto: false
+
 ---
 # Settings for local(dev)
 management.endpoints.web.exposure.include: "*"

--- a/src/test/java/com/umc/withme/service/AuthServiceTest.java
+++ b/src/test/java/com/umc/withme/service/AuthServiceTest.java
@@ -1,8 +1,10 @@
 package com.umc.withme.service;
 
+import com.umc.withme.domain.ImageFile;
 import com.umc.withme.domain.Member;
 import com.umc.withme.domain.constant.Gender;
 import com.umc.withme.dto.member.MemberDto;
+import com.umc.withme.repository.ImageFileRepository;
 import com.umc.withme.repository.MemberRepository;
 import com.umc.withme.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -28,12 +30,16 @@ class AuthServiceTest {
     @Mock
     private MemberRepository memberRepository;
     @Mock
+    private ImageFileRepository imageFileRepository;
+    @Mock
     private JwtTokenProvider jwtTokenProvider;
 
     @Test
     void 유저_정보가_주어지면_회원으로_등록한다() {
         // given
         MemberDto memberDto = createMemberDto();
+        given(imageFileRepository.existsDefaultMemberProfileImage()).willReturn(true);
+        given(imageFileRepository.getDefaultMemberProfileImage()).willReturn(createImageFile());
         given(memberRepository.save(any(Member.class))).willReturn(createMember());
 
         // when
@@ -68,14 +74,17 @@ class AuthServiceTest {
     }
 
     private Member createMember() {
-        Member member = Member.builder()
-                .email("test@daum.net")
-                .password("1234")
-                .ageRange(20)
-                .gender(Gender.MALE)
-                .build();
+        Member member = createMemberDto().toEntity(createImageFile());
         ReflectionTestUtils.setField(member, "id", 1L);
 
         return member;
+    }
+
+    private ImageFile createImageFile() {
+        return ImageFile.builder()
+                .fileName("test")
+                .storedFileName("test")
+                .url("url")
+                .build();
     }
 }

--- a/src/test/java/com/umc/withme/service/S3FileServiceTest.java
+++ b/src/test/java/com/umc/withme/service/S3FileServiceTest.java
@@ -1,0 +1,66 @@
+package com.umc.withme.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.umc.withme.domain.ImageFile;
+import com.umc.withme.repository.ImageFileRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("[Service] S3 File Upload")
+@ExtendWith(MockitoExtension.class)
+class S3FileServiceTest {
+
+    @InjectMocks
+    private S3FileService sut;
+
+    @Mock
+    private ImageFileRepository imageFileRepository;
+    @Mock
+    private AmazonS3Client s3Client;
+
+    @Test
+    void multipartFile이_주어지면_ImageFile_Entity를_생성하여_저장한_후_반환한다() {
+        // given
+        given(s3Client.putObject(any(PutObjectRequest.class))).willReturn(null);
+        given(imageFileRepository.save(any(ImageFile.class))).willReturn(createImageFileWithId());
+
+        // when
+        sut.saveFile(
+                new MockMultipartFile(
+                        "file",
+                        "test.txt",
+                        MediaType.TEXT_PLAIN_VALUE,
+                        "test".getBytes()
+                )
+        );
+
+        // then
+        then(imageFileRepository).should().save(any(ImageFile.class));
+    }
+
+    private ImageFile createImageFile() {
+        return ImageFile.builder()
+                .fileName("test")
+                .storedFileName("test")
+                .url("url")
+                .build();
+    }
+
+    private ImageFile createImageFileWithId() {
+        ImageFile imageFile = createImageFile();
+        ReflectionTestUtils.setField(imageFile, "id", 1L);
+        return imageFile;
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- Close #50 

## 작업 사항
- AWS S3 파일 업로드를 위한 의존성 추가 및 설정.
- AWS S3 기반 파일 업로드 환경 구축 및 파일을 업로드 할 수 있도록 관련 기능 구현.
- 회원가입 시 회원의 기본 프로필 이미지를 설정하는 로직 추가.
  - 이로 인해 DTO와 test 코드의 변경 사항 적용.
  - `MemberRepository`에서 회원 조회 시 주소 뿐만 아니라 프로필 이미지도 기본적으로 fetch join 하도록 설정.
- 회원 프로필 이미지 설정(변경) API 구현

## 참고 자료
- [AWS Cloud Storage(S3)](https://aws.amazon.com/ko/s3/)

## 체크리스트
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
